### PR TITLE
Cleanup LabelBinarizer

### DIFF
--- a/docs/source/cuml-accel/faq.rst
+++ b/docs/source/cuml-accel/faq.rst
@@ -75,6 +75,7 @@ the following estimators are mostly or entirely accelerated when run with
     * ``sklearn.preprocessing.MaxAbsScaler``
     * ``sklearn.preprocessing.PolynomialFeatures``
     * ``sklearn.preprocessing.LabelEncoder``
+    * ``sklearn.preprocessing.LabelBinarizer``
     * ``sklearn.preprocessing.TargetEncoder``
     * ``sklearn.svm.SVC``
     * ``sklearn.svm.SVR``

--- a/docs/source/cuml-accel/limitations.rst
+++ b/docs/source/cuml-accel/limitations.rst
@@ -463,6 +463,11 @@ LabelEncoder
 
 ``LabelEncoder`` supports all cases and will never fall back to CPU.
 
+LabelBinarizer
+^^^^^^^^^^^^^^
+
+``LabelBinarizer`` supports all cases and will never fall back to CPU.
+
 TargetEncoder
 ^^^^^^^^^^^^^
 

--- a/python/cuml/cuml/accel/_overrides/sklearn/preprocessing.py
+++ b/python/cuml/cuml/accel/_overrides/sklearn/preprocessing.py
@@ -19,6 +19,7 @@ __all__ = (
     "PolynomialFeatures",
     "TargetEncoder",
     "LabelEncoder",
+    "LabelBinarizer",
 )
 
 
@@ -56,6 +57,13 @@ class PolynomialFeatures(ArrayAPIProxyBase):
 
 class LabelEncoder(ProxyBase):
     _gpu_class = cuml.preprocessing.LabelEncoder
+
+
+class LabelBinarizer(ProxyBase):
+    _gpu_class = cuml.preprocessing.LabelBinarizer
+
+    def _gpu_inverse_transform(self, Y, threshold=None):
+        return self._gpu.inverse_transform(Y, threshold=None)
 
 
 def _check_targetencoder_y(y):

--- a/python/cuml/cuml/accel/_overrides/sklearn/preprocessing.py
+++ b/python/cuml/cuml/accel/_overrides/sklearn/preprocessing.py
@@ -63,7 +63,7 @@ class LabelBinarizer(ProxyBase):
     _gpu_class = cuml.preprocessing.LabelBinarizer
 
     def _gpu_inverse_transform(self, Y, threshold=None):
-        return self._gpu.inverse_transform(Y, threshold=None)
+        return self._gpu.inverse_transform(Y, threshold=threshold)
 
 
 def _check_targetencoder_y(y):

--- a/python/cuml/cuml/internals/validation.py
+++ b/python/cuml/cuml/internals/validation.py
@@ -591,10 +591,30 @@ def check_array(
         raise ValueError(f"Unsupported {mem_type=!r}")
     if order not in ("F", "C", "A", None):
         raise ValueError(f"Unsupported {order=!r}")
+
     if dtype is not None:
         if not isinstance(dtype, (list, tuple)):
             dtype = [dtype]
         dtype = [np.dtype(i) for i in dtype]
+
+    is_sparse = cp_sp.issparse(array) or sp.issparse(array)
+    if is_sparse and (
+        mem_type == "device" or (mem_type is None and cp_sp.issparse(array))
+    ):
+        # XXX: cupyx.scipy.sparse doesn't support integral dtypes. If a dtype
+        # is specified, we filter to only supported types (erroring if no
+        # supported types specified). If dtype=None, we use the input dtype if
+        # supported, and the closest floating type otherwise.
+        if dtype is not None:
+            if not any(d.kind in "fb" for d in dtype):
+                raise ValueError(
+                    f"No dtype in {dtype} is supported by cupyx.scipy.sparse"
+                )
+            dtype = [d for d in dtype if d.kind in "fb"]
+        elif array.dtype.kind not in "fb":
+            dtype = [
+                np.dtype("f4") if array.dtype.itemsize <= 4 else np.dtype("f8")
+            ]
 
     # Extract original array type and dtype (when possible)
     array_type = type(array)
@@ -629,13 +649,13 @@ def check_array(
         else:
             dtype = array_dtype
     elif dtype is not None:
-        # No original dtype, use first dtype in list inputs
+        # No original dtype, use first provided dtype
         dtype = dtype[0]
 
     # Coerce `array` to numpy/cupy/scipy.sparse/cupyx.scipy.sparse values as
     # requested. For dataframe-like inputs also extract the index for later use.
     index = None
-    if cp_sp.issparse(array) or sp.issparse(array):
+    if is_sparse:
         orig_sparse_array = array
         # Handle sparse inputs
         if isinstance(accept_sparse, str):
@@ -667,17 +687,23 @@ def check_array(
             ensure_min_features=ensure_min_features,
         )
 
-        # Coerce data to accepted dtype if needed
-        if dtype is not None and array.dtype != dtype:
-            array = array.astype(dtype)
-
-        # Coerce to device or host if needed
-        if mem_type == "device" and not cp_sp.issparse(array):
-            if array.ndim != 2:
-                raise ValueError("cupyx.scipy.sparse only supports 2D arrays")
-            array = getattr(cp_sp, f"{array.format}_matrix")(array)
-        elif mem_type == "host" and not sp.issparse(array):
+        # Coerce to proper dtype and mem_type if needed
+        if mem_type == "host" and not sp.issparse(array):
+            # Coerce to device, then coerce dtype. We do this to save device
+            # memory, and since scipy supports more dtypes.
             array = array.get()
+            if dtype is not None and array.dtype != dtype:
+                array = array.astype(dtype)
+        else:
+            # Otherwise coerce dtype, then mem_type if needed
+            if dtype is not None and array.dtype != dtype:
+                array = array.astype(dtype)
+            if mem_type == "device" and not cp_sp.issparse(array):
+                if array.ndim != 2:
+                    raise ValueError(
+                        "cupyx.scipy.sparse only supports 2D arrays"
+                    )
+                array = getattr(cp_sp, f"{array.format}_matrix")(array)
 
         # Copy if needed
         if copy and array is orig_sparse_array:

--- a/python/cuml/cuml/preprocessing/label.py
+++ b/python/cuml/cuml/preprocessing/label.py
@@ -185,6 +185,13 @@ def _label_binarize(
 
         out = out.astype("int32", copy=False)
 
+    # XXX: In a binary problem with unseen labels we return a matrix of shape
+    # (n_samples, 2), while sklearn returns (n_samples, 1). This is an edge
+    # case (binary inputs for `LabelBinarizer` are a bit odd, as are unseen
+    # classes. We view the sklearn behavior as a bug (see
+    # https://github.com/scikit-learn/scikit-learn/issues/13674), since with
+    # their encoding unseen labels are conflated with label 0 rather than
+    # encoded as missing via all 0s (as in the multiclass case).
     if y_type == "binary" and not has_unseen:
         out = out[:, [-1]]
 
@@ -213,9 +220,11 @@ def label_binarize(y, classes, neg_label=0, pos_label=1, sparse_output=False):
     Returns
     -------
     y : array or sparse matrix, shape (n_samples, n_classes)
-        The encoded labels. Shape will be (n_samples, 1) for binary
-        classification problems. Will be a sparse matrix if
-        ``sparse_output=True``.
+        The encoded labels. Will be a sparse matrix if ``sparse_output=True``.
+        Shape will be (n_samples, n_classes) for multiclass problems,
+        (n_samples, 1) for binary problems with no unseen classes, and
+        (n_samples, 2) for binary problems with unseen classes (a minor,
+        intentional deviation from sklearn).
 
     See Also
     --------
@@ -427,9 +436,11 @@ class LabelBinarizer(Base, InteropMixin):
         Returns
         -------
         y : array or sparse matrix
-            The encoded labels. Shape will be (n_samples, 1) for binary
-            classification problems. Will be a sparse matrix if
-            ``sparse_output=True``.
+            The encoded labels. Will be a sparse matrix if
+            ``sparse_output=True``. Shape will be (n_samples, n_classes) for
+            multiclass problems, (n_samples, 1) for binary problems with no
+            unseen classes, and (n_samples, 2) for binary problems with unseen
+            classes (a minor, intentional deviation from sklearn).
         """
         check_is_fitted(self)
         out, _, _, _ = _label_binarize(

--- a/python/cuml/cuml/preprocessing/label.py
+++ b/python/cuml/cuml/preprocessing/label.py
@@ -1,82 +1,263 @@
 # SPDX-FileCopyrightText: Copyright (c) 2020-2026, NVIDIA CORPORATION.
 # SPDX-License-Identifier: Apache-2.0
 #
-
+import cudf
 import cupy as cp
-import cupyx
-import scipy.sparse
+import cupyx.scipy.sparse as cp_sp
+import numpy as np
+import scipy.sparse as sp
 
 import cuml.internals
-from cuml.common import CumlArray
-from cuml.common.array_descriptor import CumlArrayDescriptor
-from cuml.internals.array_sparse import SparseCumlArray
+from cuml.common.classification import decode_labels
+from cuml.internals.array import CumlArray
 from cuml.internals.base import Base
-from cuml.prims.label import make_monotonic
+from cuml.internals.interop import InteropMixin
+from cuml.internals.validation import (
+    check_array,
+    check_classification_targets,
+    check_is_fitted,
+)
+
+
+def _label_binarize(
+    y,
+    *,
+    classes=...,
+    neg_label=0,
+    pos_label=1,
+    sparse_output=False,
+    accept_multilabel=True,
+):
+    """A helper used to implement `label_binarize` and `LabelBinarizer`"""
+    if neg_label >= pos_label:
+        raise ValueError(
+            f"{neg_label=} must be strictly less than {pos_label=}."
+        )
+
+    if sparse_output and (pos_label == 0 or neg_label != 0):
+        raise ValueError(
+            "Sparse binarization is only supported with non "
+            "zero pos_label and zero neg_label, got "
+            f"{pos_label=} and {neg_label=}"
+        )
+
+    if classes is not ...:
+        if hasattr(classes, "__cuda_array_interface__"):
+            classes = cp.asarray(classes)
+        else:
+            classes = np.asarray(classes)
+
+    # To account for pos_label == 0 in the dense case
+    if pos_switch := pos_label == 0:
+        pos_label = -neg_label
+
+    is_multioutput = False
+
+    if sparse_input := (cp_sp.issparse(y) or sp.issparse(y)):
+        # Coerce to cupyx.scipy.sparse.csr_matrix
+        y = check_array(
+            y,
+            dtype=("float32", "float64"),
+            accept_sparse="csr",
+            ensure_min_samples=0,
+            ensure_all_finite=False,
+        )
+        # Ensure y is integral and finite
+        check_classification_targets(y.data)
+        is_multioutput = len(cp.unique(y.data)) > 2
+    else:
+        # cudf may coerce the dtype, store the original so we can cast back later
+        input_dtype = y.dtype if isinstance(y, np.ndarray) else None
+
+        if not isinstance(y, (cudf.DataFrame, cudf.Series)):
+            y = check_array(
+                y,
+                mem_type=None,
+                ensure_2d=False,
+                ensure_min_samples=0,
+                ensure_all_finite=False,
+                input_name="y",
+            )
+            # If no original dtype found on input, use the coerced one instead
+            if input_dtype is None:
+                input_dtype = y.dtype
+
+            y = (cudf.DataFrame if y.ndim == 2 else cudf.Series)(
+                y, dtype=(np.dtype("O") if y.dtype.kind in "U" else None)
+            )
+        else:
+            y = y.reset_index(drop=True)
+
+        if y.ndim == 2 and y.shape[1] == 1:
+            y = y.iloc[:, 0]
+        if y.ndim == 1:
+            check_classification_targets(y)
+        elif y.ndim == 2:
+            if y.select_dtypes(exclude=["number", "bool"]).shape[1]:
+                is_multioutput = True
+            else:
+                y = y.to_cupy()
+                check_classification_targets(y)
+                is_multioutput = len(cp.unique(y)) > 2
+
+    if is_multioutput:
+        raise ValueError(
+            "Multioutput target data is not supported with label binarization"
+        )
+
+    if y.shape[0] == 0:
+        raise ValueError("y has 0 samples, while a minimum of 1 is required")
+
+    has_unseen = False
+    if y.ndim == 1:
+        # binary or multiclass
+        # y is a cudf.Series
+        y = y.astype("category")
+        if classes is ...:
+            classes = y.cat.categories
+            # XXX: cudf's to_numpy doesn't support conversions for all
+            # dtypes. Roundtrip through object dtype when necessary.
+            try:
+                classes = classes.to_numpy(dtype=input_dtype)
+            except NotImplementedError:
+                classes = classes.to_numpy(dtype="object")
+            # cudf will sometimes translate non-numeric dtypes. Coerce back to
+            # the input dtype if the input was originally a numpy array.
+            if input_dtype is not None:
+                classes = classes.astype(input_dtype, copy=False)
+            indices = cp.asarray(y.cat.codes)
+            indptr = cp.arange(len(y) + 1)
+        else:
+            y = y.cat.set_categories(classes)
+            if has_unseen := y.has_nulls:
+                mask = ~y.isnull()
+                indices = cp.asarray(y[mask].cat.codes)
+                indptr = cp.concatenate([cp.array([0]), mask.cumsum()])
+            else:
+                indices = cp.asarray(y.cat.codes)
+                indptr = cp.arange(len(y) + 1)
+
+        if len(classes) == 1:
+            # Special case binary with 1 class -> neg_label
+            y_type = "binary"
+            out = cp_sp.csr_matrix((len(y), 1), dtype="float32")
+        else:
+            y_type = "binary" if len(classes) <= 2 else "multiclass"
+            data = cp.full(len(indices), pos_label, dtype="float32")
+            out = cp_sp.csr_matrix(
+                (data, indices, indptr), shape=(len(y), len(classes))
+            )
+        if not sparse_output:
+            out = out.toarray()
+    else:
+        # multilabel-indicator
+        # y is a cupy.ndarray or cupyx.scipy.sparse.csr_matrix
+        y_type = "multilabel-indicator"
+
+        if not accept_multilabel:
+            raise ValueError(
+                "The object was not fitted with multilabel input."
+            )
+
+        if classes is ...:
+            classes = np.arange(y.shape[1])
+        elif len(classes) != y.shape[1]:
+            raise ValueError(
+                f"classes {classes} mismatch with the labels "
+                f"{np.arange(y.shape[1])} found in the data"
+            )
+
+        if sparse_output:
+            out = cp_sp.csr_matrix(y.astype("float32"))
+            if pos_label != 1:
+                out.data = cp.full_like(out.data, pos_label)
+        else:
+            out = y.toarray() if cp_sp.issparse(y) else y.copy()
+            if pos_label != 1:
+                out[out != 0] = pos_label
+
+    if not sparse_output:
+        if neg_label != 0:
+            out[out == 0] = neg_label
+
+        if pos_switch:
+            out[out == pos_label] = 0
+
+        out = out.astype("int32", copy=False)
+
+    if y_type == "binary" and not has_unseen:
+        out = out[:, [-1]]
+
+    return out, classes, y_type, sparse_input
 
 
 @cuml.internals.reflect
-def label_binarize(
-    y, classes, neg_label=0, pos_label=1, sparse_output=False
-) -> SparseCumlArray:
+def label_binarize(y, classes, neg_label=0, pos_label=1, sparse_output=False):
     """
-    A stateless helper function to dummy encode multi-class labels.
+    Binarize labels in a one-vs-all fashion.
 
     Parameters
     ----------
+    y : array-like or sparse matrix, shape (n_samples,) or (n_samples, n_classes)
+        Target values. The 2-d matrix should only contain 0 and 1, in the
+        multilabel-indicator format.
+    classes : array-like of shape (n_classes,)
+        The class labels for each class.
+    neg_label : int, default=0
+        The value to use for encoding negative labels.
+    pos_label : int, default=1
+        The value to use for encoding positive labels.
+    sparse_output : bool, default=False
+        If true, a sparse CSR matrix is returned.
 
-    y : array-like of size [n_samples,] or [n_samples, n_classes]
-    classes : the set of unique classes in the input
-    neg_label : integer the negative value for transformed output
-    pos_label : integer the positive value for transformed output
-    sparse_output : bool whether to return sparse array
+    Returns
+    -------
+    y : array or sparse matrix, shape (n_samples, n_classes)
+        The encoded labels. Shape will be (n_samples, 1) for binary
+        classification problems. Will be a sparse matrix if
+        ``sparse_output=True``.
+
+    See Also
+    --------
+    LabelBinarizer : A class version of this function.
+
+    Examples
+    --------
+    >>> from cuml.preprocessing import label_binarize
+    >>> label_binarize([1, 6], classes=[1, 2, 4, 6])
+    array([[1, 0, 0, 0],
+           [0, 0, 0, 1]], dtype=int32)
+
+    Binary targets result in a column vector:
+
+    >>> label_binarize(['a', 'b', 'b', 'a'], classes=['a', 'b'])
+    array([[0],
+           [1],
+           [1],
+           [0]], dtype=int32)
     """
-
-    classes = cp.asarray(classes, dtype=classes.dtype)
-    labels = cp.asarray(y, dtype=y.dtype)
-
-    # Check that all labels are in classes
-    if not bool(cp.all(cp.isin(labels, classes))):
-        raise ValueError("Unseen classes encountered in input")
-
-    row_ind = cp.arange(0, labels.shape[0], 1, dtype=y.dtype)
-    col_ind, _ = make_monotonic(labels, classes, copy=True)
-
-    val = cp.full(row_ind.shape[0], pos_label, dtype=y.dtype)
-
-    sp = cupyx.scipy.sparse.coo_matrix(
-        (val, (row_ind, col_ind)),
-        shape=(col_ind.shape[0], classes.shape[0]),
-        dtype=cp.float32,
+    out, _, _, _ = _label_binarize(
+        y,
+        classes=classes,
+        neg_label=neg_label,
+        pos_label=pos_label,
+        sparse_output=sparse_output,
     )
-
-    is_binary = classes.shape[0] == 2
-
-    if sparse_output:
-        sp = sp.tocsr()
-        if is_binary:
-            sp = sp.getcol(1)  # getcol does not support -1 indexing
-        return sp
-    else:
-        arr = sp.toarray().astype(y.dtype)
-        arr[arr == 0] = neg_label
-        if is_binary:
-            arr = arr[:, -1].reshape((-1, 1))
-        return arr
+    return out
 
 
-class LabelBinarizer(Base):
+class LabelBinarizer(Base, InteropMixin):
     """
-    A multi-class dummy encoder for labels.
+    Binarize labels in a one-vs-all fashion.
 
     Parameters
     ----------
-
-    neg_label : integer (default=0)
-        label to be used as the negative binary label
-    pos_label : integer (default=1)
-        label to be used as the positive binary label
-    sparse_output : bool (default=False)
-        whether to return sparse arrays for transformed output
+    neg_label : int, default=0
+        The value to use for encoding negative labels.
+    pos_label : int, default=1
+        The value to use for encoding positive labels.
+    sparse_output : bool, default=False
+        If true, a sparse CSR matrix is returned from ``transform``.
     verbose : int or boolean, default=False
         Sets logging level. It must be one of `cuml.common.logger.level_*`.
         See :ref:`verbosity-levels` for more info.
@@ -87,43 +268,43 @@ class LabelBinarizer(Base):
         (`cuml.global_settings.output_type`) will be used. See
         :ref:`output-data-type-configuration` for more info.
 
+    Attributes
+    ----------
+    classes_ : numpy.ndarray of shape (n_classes,)
+        Holds the label for each class.
+    y_type_ : {'binary', 'multiclass', 'multilabel-indicator'}
+        The type of the target data.
+    sparse_input_ : bool
+        Whether the input data to `fit` was a sparse matrix.
+
+    See Also
+    --------
+    label_binarize : A function version of this class.
+
     Examples
     --------
+    >>> import cupy as cp
+    >>> from cuml.preprocessing import LabelBinarizer
+    >>> y = cp.array([1, 2, 6, 4, 2])
+    >>> lb = LabelBinarizer().fit(y)
+    >>> lb.classes_
+    array([1, 2, 4, 6])
+    >>> lb.transform(cp.array([1, 6]))
+    array([[1, 0, 0, 0],
+           [0, 0, 0, 1]], dtype=int32)
 
-    Create an array with labels and dummy encode them
+    Binary targets result in a column vector:
 
-    .. code-block:: python
-
-        >>> import cupy as cp
-        >>> import cupyx
-        >>> from cuml.preprocessing import LabelBinarizer
-
-        >>> labels = cp.asarray([0, 5, 10, 7, 2, 4, 1, 0, 0, 4, 3, 2, 1],
-        ...                     dtype=cp.int32)
-
-        >>> lb = LabelBinarizer()
-        >>> encoded = lb.fit_transform(labels)
-        >>> print(str(encoded))
-        [[1 0 0 0 0 0 0 0]
-        [0 0 0 0 0 1 0 0]
-        [0 0 0 0 0 0 0 1]
-        [0 0 0 0 0 0 1 0]
-        [0 0 1 0 0 0 0 0]
-        [0 0 0 0 1 0 0 0]
-        [0 1 0 0 0 0 0 0]
-        [1 0 0 0 0 0 0 0]
-        [1 0 0 0 0 0 0 0]
-        [0 0 0 0 1 0 0 0]
-        [0 0 0 1 0 0 0 0]
-        [0 0 1 0 0 0 0 0]
-        [0 1 0 0 0 0 0 0]]
-        >>> decoded = lb.inverse_transform(encoded)
-        >>> print(str(decoded))
-        [ 0  5 10  7  2  4  1  0  0  4  3  2  1]
-
+    >>> import numpy as np
+    >>> lb = LabelBinarizer()
+    >>> lb.fit_transform(np.array(['a', 'b', 'b', 'a']))
+    array([[0],
+           [1],
+           [1],
+           [0]], dtype=int32)
     """
 
-    classes_ = CumlArrayDescriptor()
+    _cpu_class_path = "sklearn.preprocessing.LabelBinarizer"
 
     def __init__(
         self,
@@ -135,128 +316,219 @@ class LabelBinarizer(Base):
         output_type=None,
     ):
         super().__init__(verbose=verbose, output_type=output_type)
-
-        if neg_label >= pos_label:
-            raise ValueError(
-                "neg_label=%s must be less "
-                "than pos_label=%s." % (neg_label, pos_label)
-            )
-
-        if sparse_output and (pos_label == 0 or neg_label != 0):
-            raise ValueError(
-                "Sparse binarization is only supported "
-                "with non-zero"
-                "pos_label and zero neg_label, got pos_label=%s "
-                "and neg_label=%s" % (pos_label, neg_label)
-            )
-
         self.neg_label = neg_label
         self.pos_label = pos_label
         self.sparse_output = sparse_output
-        self.classes_ = None
 
-    @cuml.internals.reflect(reset="type")
+    @classmethod
+    def _get_param_names(cls):
+        return [
+            *super()._get_param_names(),
+            "neg_label",
+            "pos_label",
+            "sparse_output",
+        ]
+
+    def __sklearn_is_fitted__(self) -> bool:
+        return hasattr(self, "classes_")
+
+    @staticmethod
+    def _more_static_tags():
+        return {"X_types": ["1dlabels"]}
+
+    @classmethod
+    def _params_from_cpu(cls, model):
+        return {
+            "neg_label": model.neg_label,
+            "pos_label": model.pos_label,
+            "sparse_output": model.sparse_output,
+        }
+
+    def _params_to_cpu(self):
+        return {
+            "neg_label": self.neg_label,
+            "pos_label": self.pos_label,
+            "sparse_output": self.sparse_output,
+        }
+
+    def _attrs_from_cpu(self, model):
+        return {
+            "y_type_": model.y_type_,
+            "sparse_input_": model.sparse_input_,
+            "classes_": model.classes_,
+        }
+
+    def _attrs_to_cpu(self, model):
+        return {
+            "y_type_": self.y_type_,
+            "sparse_input_": self.sparse_input_,
+            "classes_": self.classes_,
+        }
+
+    @cuml.internals.run_in_internal_context
     def fit(self, y) -> "LabelBinarizer":
         """
-        Fit label binarizer
+        Fit label binarizer.
 
         Parameters
         ----------
         y : array of shape [n_samples,] or [n_samples, n_classes]
             Target values. The 2-d matrix should only contain 0 and 1,
-            represents multilabel classification.
+            in the multilabel-indicator format.
 
         Returns
         -------
-        self : returns an instance of self.
+        self : LabelBinarizer
+            Returns the instance itself.
         """
-
-        if y.ndim > 2:
-            raise ValueError("labels cannot be greater than 2 dimensions")
-
-        if y.ndim == 2:
-            unique_classes = cp.unique(y)
-            if unique_classes != [0, 1]:
-                raise ValueError("2-d array can must be binary")
-
-            self.classes_ = cp.arange(0, y.shape[1])
-        else:
-            self.classes_ = cp.unique(y).astype(y.dtype)
-
+        self.fit_transform(y)
         return self
 
-    @cuml.internals.reflect
-    def fit_transform(self, y) -> SparseCumlArray:
+    @cuml.internals.reflect(reset="type")
+    def fit_transform(self, y):
         """
-        Fit label binarizer and transform multi-class labels to their
-        dummy-encoded representation.
+        Fit label binarizer and transform labels to binary labels.
 
         Parameters
         ----------
-        y : array of shape [n_samples,] or [n_samples, n_classes]
+        y : array-like or sparse matrix, shape (n_samples,) or (n_samples, n_classes)
+            Target values. The 2-d matrix should only contain 0 and 1, in the
+            multilabel-indicator format.
 
         Returns
         -------
-
-        arr : array with encoded labels
+        y : array or sparse matrix
+            The encoded labels. Shape will be (n_samples, 1) for binary
+            classification problems. Will be a sparse matrix if
+            ``sparse_output=True``.
         """
-        return self.fit(y).transform(y)
-
-    @cuml.internals.reflect
-    def transform(self, y) -> SparseCumlArray:
-        """
-        Transform multi-class labels to their dummy-encoded representation
-        labels.
-
-        Parameters
-        ----------
-        y : array of shape [n_samples,] or [n_samples, n_classes]
-
-        Returns
-        -------
-        arr : array with encoded labels
-        """
-        return label_binarize(
+        out, classes, y_type, sparse_input = _label_binarize(
             y,
-            self.classes_,
-            pos_label=self.pos_label,
             neg_label=self.neg_label,
+            pos_label=self.pos_label,
             sparse_output=self.sparse_output,
         )
+        self.classes_ = classes
+        self.y_type_ = y_type
+        self.sparse_input_ = sparse_input
+        return out
 
     @cuml.internals.reflect
-    def inverse_transform(self, y, *, threshold=None) -> CumlArray:
+    def transform(self, y):
         """
-        Transform binary labels back to original multi-class labels
+        Transform labels to binary labels.
 
         Parameters
         ----------
-
-        y : array of shape [n_samples, n_classes]
-        threshold : float this value is currently ignored
+        y : array-like or sparse matrix, shape (n_samples,) or (n_samples, n_classes)
+            Target values. The 2-d matrix should only contain 0 and 1, in the
+            multilabel-indicator format.
 
         Returns
         -------
-
-        arr : array with original labels
+        y : array or sparse matrix
+            The encoded labels. Shape will be (n_samples, 1) for binary
+            classification problems. Will be a sparse matrix if
+            ``sparse_output=True``.
         """
-        # If we are already given multi-class, just return it.
-        if cupyx.scipy.sparse.isspmatrix(y):
-            y_mapped = y.tocsr().indices.astype(self.classes_.dtype)
-        elif scipy.sparse.isspmatrix(y):
-            y = y.tocsr()
-            y_mapped = cp.array(y.indices, dtype=y.indices.dtype)
-        else:
-            y_mapped = cp.argmax(cp.asarray(y, dtype=y.dtype), axis=1).astype(
-                y.dtype
+        check_is_fitted(self)
+        out, _, _, _ = _label_binarize(
+            y,
+            classes=self.classes_,
+            neg_label=self.neg_label,
+            pos_label=self.pos_label,
+            sparse_output=self.sparse_output,
+            accept_multilabel=self.y_type_ == "multilabel-indicator",
+        )
+        return out
+
+    @cuml.internals.run_in_internal_context
+    def inverse_transform(self, y, *, threshold=None):
+        """
+        Transform binary labels back to original labels.
+
+        Parameters
+        ----------
+        y : array-like or sparse matrix, shape (n_samples, n_classes)
+            The encoded target values.
+        threshold : float, default=None
+            Threshold used in the binary and multilabel-indicator cases.
+            If None, the threshold is assumed to be half way between
+            ``neg_label`` and ``pos_label``.
+
+        Returns
+        -------
+        y : array or sparse matrix, shape (n_samples,) or (n_samples, n_classes)
+            The original target values.
+        """
+        check_is_fitted(self)
+
+        # Determine output type
+        with cuml.internals.exit_internal_context():
+            output_type = self._get_output_type(y)
+
+        # Validate and normalize y to a cupy array or csr_matrix
+        y, index = check_array(
+            y,
+            ensure_2d=False,
+            ensure_min_samples=0,
+            accept_sparse="csr",
+            return_index=True,
+        )
+        if y.ndim == 1:
+            y = y[:, None]
+
+        # Ensure shape is valid with fit classes
+        n_classes = len(self.classes_)
+        if n_classes == 2 and y.shape[1] not in (1, 2):
+            raise ValueError(
+                f"Expected `y` with 1 or 2 columns, but got {y.shape[1]}"
+            )
+        elif n_classes != 2 and y.shape[1] != n_classes:
+            raise ValueError(
+                f"Expected `y` with {n_classes} columns, but got {y.shape[1]}"
             )
 
-        return CumlArray(data=self.classes_[y_mapped])
+        # Transform back to original input
+        if self.y_type_ == "multiclass":
+            if cp_sp.issparse(y):
+                indices = y.argmax(1).flatten()
+            else:
+                indices = y.argmax(axis=1)
+        else:
+            if threshold is None:
+                threshold = (self.pos_label + self.neg_label) / 2.0
 
-    @classmethod
-    def _get_param_names(cls):
-        return super()._get_param_names() + [
-            "neg_label",
-            "pos_label",
-            "sparse_output",
-        ]
+            if cp_sp.issparse(y):
+                if threshold > 0:
+                    indices = (y > threshold).toarray().view("int8")
+                else:
+                    # Results in a fully dense output, pre-densify to save memory
+                    indices = (y.toarray() > threshold).view("int8")
+            else:
+                indices = (y > threshold).view("int8")
+
+            if self.y_type_ == "binary":
+                if cp_sp.issparse(indices):
+                    indices = indices.toarray()
+                if y.ndim == 2 and y.shape[1] == 2:
+                    indices = indices[:, 1].flatten()
+                elif n_classes == 1:
+                    indices = cp.zeros(len(y), dtype="int8")
+                else:
+                    indices = indices.flatten()
+
+        if self.y_type_ in ("binary", "multiclass"):
+            return decode_labels(
+                indices, self.classes_, output_type=output_type, index=index
+            )
+
+        # For multilabel-indicator we need to handle the conversion manually
+        if self.sparse_input_:
+            out = cp_sp.csr_matrix(indices.astype("float32", copy=False))
+            if output_type in ("numpy", "pandas"):
+                out = out.get()
+            return out
+        else:
+            out = indices.astype("int32", copy=False)
+            return CumlArray(out, index=index).to_output(output_type)

--- a/python/cuml/cuml_accel_tests/integration/test_preprocessing.py
+++ b/python/cuml/cuml_accel_tests/integration/test_preprocessing.py
@@ -4,8 +4,10 @@
 import numpy as np
 import pandas as pd
 import pytest
+import scipy.sparse as sp
 from sklearn.datasets import make_blobs
 from sklearn.preprocessing import (
+    LabelBinarizer,
     LabelEncoder,
     MaxAbsScaler,
     MinMaxScaler,
@@ -118,3 +120,41 @@ def test_label_encoder():
     np.testing.assert_array_equal(enc.classes_, np.array(["a", "b"]))
     y3 = enc.inverse_transform(y2)
     np.testing.assert_array_equal(y3, y)
+
+
+def test_label_binarizer():
+    y = np.array(["a", "b", "a", "c"])
+    enc = LabelBinarizer()
+
+    y2 = enc.fit_transform(y)
+    sol = np.array([[1, 0, 0], [0, 1, 0], [1, 0, 0], [0, 0, 1]])
+    np.testing.assert_array_equal(y2, sol)
+
+    np.testing.assert_array_equal(enc.classes_, np.array(["a", "b", "c"]))
+    assert enc.classes_.dtype == y.dtype
+    assert enc.y_type_ == "multiclass"
+
+    y3 = enc.transform(np.array(["a", "d"]))
+    sol = np.array([[1, 0, 0], [0, 0, 0]])
+    np.testing.assert_array_equal(y3, sol)
+
+    y4 = enc.inverse_transform(y2)
+    np.testing.assert_array_equal(y4, y)
+
+
+@pytest.mark.parametrize("sparse", [True, False])
+def test_label_binarizer_multilabel_indicator(sparse):
+    y = np.array([[1, 0, 0], [0, 1, 0], [0, 0, 1]])
+    if sparse:
+        y = sp.csr_matrix(y)
+    enc = LabelBinarizer().fit(y)
+    np.testing.assert_array_equal(enc.classes_, np.array([0, 1, 2]))
+    assert enc.y_type_ == "multilabel-indicator"
+
+    y2 = enc.inverse_transform(y)
+    if sparse:
+        assert isinstance(y2, sp.csr_matrix)
+        np.testing.assert_array_equal(y.toarray(), y2.toarray())
+    else:
+        assert isinstance(y2, np.ndarray)
+        np.testing.assert_array_equal(y, y2)

--- a/python/cuml/tests/test_label_binarizer.py
+++ b/python/cuml/tests/test_label_binarizer.py
@@ -244,6 +244,22 @@ def test_label_binarizer_multilabel_indicator(
     np.testing.assert_array_equal(res, sol)
 
 
+@pytest.mark.parametrize("threshold", [1, -1])
+@pytest.mark.parametrize("sparse", [False, True])
+def test_label_binarizer_inverse_transform_threshold(threshold, sparse):
+    lb = LabelBinarizer().fit(np.array(["a", "b", "c"]))
+
+    p = threshold + 1
+    n = threshold - 1
+    y = np.array([[n, p, n], [p, n, n], [n, n, p]])
+    sol = np.array(["b", "a", "c"])
+    if sparse:
+        y = sp.csr_matrix(y)
+
+    res = lb.inverse_transform(y, threshold=threshold)
+    np.testing.assert_array_equal(res, sol)
+
+
 def test_label_binarize_respects_class_order():
     out = label_binarize([1, 6], classes=[1, 2, 4, 6])
     expected = cp.array([[1, 0, 0, 0], [0, 0, 0, 1]])

--- a/python/cuml/tests/test_label_binarizer.py
+++ b/python/cuml/tests/test_label_binarizer.py
@@ -4,11 +4,9 @@
 import cupy as cp
 import numpy as np
 import pytest
-import scipy.sparse
-from sklearn.preprocessing import LabelBinarizer as skLB
+import scipy.sparse as sp
 
-from cuml.preprocessing import LabelBinarizer
-from cuml.testing.utils import array_equal
+from cuml.preprocessing import LabelBinarizer, label_binarize
 
 
 def test_label_binarizer_no_features():
@@ -18,44 +16,246 @@ def test_label_binarizer_no_features():
     assert not hasattr(model, "n_features_in_")
 
 
+def test_label_binarizer_not_fitted():
+    lb = LabelBinarizer()
+    err_msg = "This LabelBinarizer instance is not fitted yet"
+    with pytest.raises(ValueError, match=err_msg):
+        lb.transform([])
+    with pytest.raises(ValueError, match=err_msg):
+        lb.inverse_transform([])
+
+
+def test_label_binarizer_invalid_parameters():
+    input_labels = [0, 1, 0, 1]
+    err_msg = "neg_label=2 must be strictly less than pos_label=1."
+    lb = LabelBinarizer(neg_label=2, pos_label=1)
+    with pytest.raises(ValueError, match=err_msg):
+        lb.fit(input_labels)
+    err_msg = "neg_label=2 must be strictly less than pos_label=2."
+    lb = LabelBinarizer(neg_label=2, pos_label=2)
+    with pytest.raises(ValueError, match=err_msg):
+        lb.fit(input_labels)
+    err_msg = (
+        "Sparse binarization is only supported with non zero pos_label and zero "
+        "neg_label, got pos_label=2 and neg_label=1"
+    )
+    lb = LabelBinarizer(neg_label=1, pos_label=2, sparse_output=True)
+    with pytest.raises(ValueError, match=err_msg):
+        lb.fit(input_labels)
+
+
+def test_label_binarizer_invalid_y_types():
+    err_msg = (
+        "Multioutput target data is not supported with label binarization"
+    )
+    with pytest.raises(ValueError, match=err_msg):
+        LabelBinarizer().fit(np.array([[1, 3], [2, 1]]))
+    with pytest.raises(ValueError, match=err_msg):
+        label_binarize(np.array([[1, 3], [2, 1]]), classes=[1, 2, 3])
+
+    with pytest.raises(ValueError, match="Unknown label type: continuous"):
+        LabelBinarizer().fit([1.2, 2.7])
+
+
+def test_label_binarize_mismatch_labels():
+    with pytest.raises(ValueError, match="mismatch with the labels"):
+        label_binarize([[1, 0]], classes=[0, 1, 2])
+
+    lb = LabelBinarizer().fit(np.array([[0, 0, 1]]))
+    with pytest.raises(ValueError, match="mismatch with the labels"):
+        lb.transform(np.array([[0, 1]]))
+
+
+def toarray(x, expect_sparse):
+    if expect_sparse:
+        assert sp.issparse(x)
+        return x.toarray()
+    return x
+
+
 @pytest.mark.parametrize(
-    "labels",
+    "sparse_output, p, n",
     [
-        ([1, 4, 5, 2, 0, 1, 6, 2, 3, 4], [4, 2, 6, 3, 2, 0, 1]),
-        ([9, 8, 2, 1, 3, 4], [8, 2, 1, 2, 2]),
+        (False, 1, 0),
+        (False, 10, 0),
+        (False, 0, -10),
+        (False, 1, -1),
+        (True, 1, 0),
+        (True, 10, 0),
     ],
 )
-@pytest.mark.parametrize("dtype", [cp.int32, cp.int64])
-@pytest.mark.parametrize("sparse_output", [True, False])
-def test_basic_functions(labels, dtype, sparse_output):
-    fit_labels, xform_labels = labels
+def test_label_binarizer_one_class(sparse_output, p, n):
+    y = np.array(["a", "a", "a"])
+    lb = LabelBinarizer(sparse_output=sparse_output, pos_label=p, neg_label=n)
 
-    skl_bin = skLB(sparse_output=sparse_output)
-    skl_bin.fit(fit_labels)
+    # fit_transform
+    sol = np.array([n, n, n])[:, None]
+    res = toarray(lb.fit_transform(y), sparse_output)
+    np.testing.assert_array_equal(res, sol)
 
-    fit_labels = cp.asarray(fit_labels, dtype=dtype)
-    xform_labels = cp.asarray(xform_labels, dtype=dtype)
+    # transform
+    res = toarray(lb.transform(y), sparse_output)
+    np.testing.assert_array_equal(res, sol)
 
-    binarizer = LabelBinarizer(sparse_output=sparse_output)
-    binarizer.fit(fit_labels)
+    # attributes
+    assert lb.y_type_ == "binary"
+    assert not lb.sparse_input_
+    np.testing.assert_array_equal(lb.classes_, np.array(["a"]))
 
-    assert array_equal(binarizer.classes_.get(), np.unique(fit_labels.get()))
+    # inverse_transform
+    np.testing.assert_array_equal(lb.inverse_transform(res), y)
 
-    xformed = binarizer.transform(xform_labels)
+    # transform unseen labels
+    unseen = np.array(["a", "b"])
+    res = toarray(lb.transform(unseen), sparse_output)
+    sol = np.array([n, n])[:, None]
+    np.testing.assert_array_equal(res, sol)
 
-    if sparse_output:
-        skl_bin_xformed = skl_bin.transform(xform_labels.get())
 
-        skl_csr = scipy.sparse.coo_matrix(skl_bin_xformed).tocsr()
-        cuml_csr = xformed
+@pytest.mark.parametrize(
+    "sparse_output, p, n",
+    [
+        (False, 1, 0),
+        (False, 10, 0),
+        (False, 0, -10),
+        (False, 1, -1),
+        (True, 1, 0),
+        (True, 10, 0),
+    ],
+)
+def test_label_binarizer_two_classes(sparse_output, p, n):
+    y = np.array(["a", "b", "b", "a"])
+    lb = LabelBinarizer(sparse_output=sparse_output, pos_label=p, neg_label=n)
 
-        array_equal(skl_csr.data, cuml_csr.data.get())
+    # fit_transform
+    sol = np.array([n, p, p, n])[:, None]
+    res = toarray(lb.fit_transform(y), sparse_output)
+    np.testing.assert_array_equal(res, sol)
 
-        # #todo: Support sparse inputs
-        # xformed = xformed.todense().astype(dtype)
+    # transform
+    res = toarray(lb.transform(y), sparse_output)
+    np.testing.assert_array_equal(res, sol)
 
-    assert xformed.shape[1] == binarizer.classes_.shape[0]
+    # attributes
+    assert lb.y_type_ == "binary"
+    assert not lb.sparse_input_
+    np.testing.assert_array_equal(lb.classes_, np.array(["a", "b"]))
 
-    original = binarizer.inverse_transform(xformed)
+    # inverse_transform
+    np.testing.assert_array_equal(lb.inverse_transform(res), y)
+    # can also invert 2 column output
+    y2 = np.array([[p, n], [n, p], [n, p], [p, n]])
+    np.testing.assert_array_equal(lb.inverse_transform(y2), y)
 
-    assert array_equal(original.get(), xform_labels.get())
+    # transform of unseen classes results in 2 columns
+    unseen = np.array(["a", "b", "c"])
+    res = toarray(lb.transform(unseen), sparse_output)
+    sol = np.array([[p, n], [n, p], [n, n]])
+    np.testing.assert_array_equal(res, sol)
+
+
+@pytest.mark.parametrize(
+    "sparse_output, p, n",
+    [
+        (False, 1, 0),
+        (False, 10, 0),
+        (False, 0, -10),
+        (False, 1, -1),
+        (True, 1, 0),
+        (True, 10, 0),
+    ],
+)
+def test_label_binarizer_multiclass(sparse_output, p, n):
+    y = np.array(["a", "b", "b", "a", "c"])
+    lb = LabelBinarizer(sparse_output=sparse_output, pos_label=p, neg_label=n)
+
+    # fit_transform
+    sol = np.array([[p, n, n], [n, p, n], [n, p, n], [p, n, n], [n, n, p]])
+    res = toarray(lb.fit_transform(y), sparse_output)
+    np.testing.assert_array_equal(res, sol)
+
+    # transform
+    res = toarray(lb.transform(y), sparse_output)
+    np.testing.assert_array_equal(res, sol)
+
+    # attributes
+    assert lb.y_type_ == "multiclass"
+    assert not lb.sparse_input_
+    np.testing.assert_array_equal(lb.classes_, np.array(["a", "b", "c"]))
+
+    # inverse_transform
+    np.testing.assert_array_equal(lb.inverse_transform(res), y)
+
+    # transform of unseen inputs results in all 0s
+    unseen = np.array(["d", "a", "e", "c", "f"])
+    res = toarray(lb.transform(unseen), sparse_output)
+    sol = np.array([[n, n, n], [p, n, n], [n, n, n], [n, n, p], [n, n, n]])
+    np.testing.assert_array_equal(res, sol)
+
+
+@pytest.mark.parametrize(
+    "sparse_output, p, n",
+    [
+        (False, 1, 0),
+        (False, 10, 0),
+        (False, 0, -10),
+        (False, 1, -1),
+        (True, 1, 0),
+        (True, 10, 0),
+    ],
+)
+@pytest.mark.parametrize("sparse_input", [False, True])
+def test_label_binarizer_multilabel_indicator(
+    sparse_input, sparse_output, p, n
+):
+    y = np.array([[0, 0, 1], [1, 0, 0], [0, 1, 0]])
+    if sparse_input:
+        y = sp.csr_matrix(y)
+    lb = LabelBinarizer(sparse_output=sparse_output, pos_label=p, neg_label=n)
+
+    # fit_transform
+    sol = np.array([[n, n, p], [p, n, n], [n, p, n]])
+    res = toarray(lb.fit_transform(y), sparse_output)
+    np.testing.assert_array_equal(res, sol)
+
+    # transform
+    res = toarray(lb.transform(y), sparse_output)
+    np.testing.assert_array_equal(res, sol)
+
+    # attributes
+    assert lb.y_type_ == "multilabel-indicator"
+    assert lb.sparse_input_ is sparse_input
+    np.testing.assert_array_equal(lb.classes_, np.array([0, 1, 2]))
+
+    # inverse_transform accepts both sparse and dense,
+    # and returns the type used for fit
+    sol = np.array([[0, 1, 0], [1, 0, 0]])
+    y_dense = np.array([[n, p, n], [p, n, n]])
+    y_sparse = sp.csr_matrix(y_dense)
+    res = toarray(lb.inverse_transform(y_dense), sparse_input)
+    np.testing.assert_array_equal(res, sol)
+    res = toarray(lb.inverse_transform(y_sparse), sparse_input)
+    np.testing.assert_array_equal(res, sol)
+
+    # Can also transform non-multilabel input
+    y = np.array([3, 2, 1, 0])
+    sol = np.array([[n, n, n], [n, n, p], [n, p, n], [p, n, n]])
+    res = toarray(lb.transform(y), sparse_output)
+    np.testing.assert_array_equal(res, sol)
+
+
+def test_label_binarize_respects_class_order():
+    out = label_binarize([1, 6], classes=[1, 2, 4, 6])
+    expected = cp.array([[1, 0, 0, 0], [0, 0, 0, 1]])
+    cp.testing.assert_array_equal(out, expected)
+
+    # Modified class order
+    out = label_binarize([1, 6], classes=[1, 6, 4, 2])
+    expected = cp.array([[1, 0, 0, 0], [0, 1, 0, 0]])
+    cp.testing.assert_array_equal(out, expected)
+
+    out = label_binarize([0, 1, 2, 3], classes=[3, 2, 0, 1])
+    expected = cp.array(
+        [[0, 0, 1, 0], [0, 0, 0, 1], [0, 1, 0, 0], [1, 0, 0, 0]]
+    )
+    cp.testing.assert_array_equal(out, expected)

--- a/python/cuml/tests/test_naive_bayes.py
+++ b/python/cuml/tests/test_naive_bayes.py
@@ -34,24 +34,17 @@ from cuml.naive_bayes import (
 
 @pytest.mark.parametrize("x_dtype", [cp.int32, cp.int64])
 @pytest.mark.parametrize("y_dtype", [cp.int32, cp.int64])
-def test_sparse_integral_dtype_fails(x_dtype, y_dtype, sparse_text_dataset):
+def test_sparse_integral_dtypes_work(x_dtype, y_dtype, sparse_text_dataset):
+    """These require a bit of special casing since cupyx doesn't support
+    integral spasre matrices"""
     X, y = sparse_text_dataset
 
     X = X.astype(x_dtype)
     y = y.astype(y_dtype)
 
-    model = MultinomialNB()
-
-    with pytest.raises(ValueError):
-        model.fit(X, y)
-
-    X = X.astype(cp.float32)
-    model.fit(X, y)
-
-    X = X.astype(x_dtype)
-
-    with pytest.raises(ValueError):
-        model.predict(X)
+    model = MultinomialNB().fit(X, y)
+    out = model.predict(X)
+    assert out.dtype == y.dtype
 
 
 @pytest.mark.parametrize("x_dtype", [cp.float32, cp.float64, cp.int32])

--- a/python/cuml/tests/test_sklearn_import_export.py
+++ b/python/cuml/tests/test_sklearn_import_export.py
@@ -1041,3 +1041,27 @@ def test_label_encoder():
 
     np.testing.assert_array_equal(cu_out, sol)
     np.testing.assert_array_equal(sk_out, sol)
+
+
+def test_label_binarizer():
+    y = np.array(["a", "b", "c", "a"])
+    cu_model = cuml.preprocessing.LabelBinarizer().fit(y)
+    sk_model = sklearn.preprocessing.LabelBinarizer().fit(y)
+
+    cu_model2 = cuml.preprocessing.LabelBinarizer.from_sklearn(sk_model)
+    sk_model2 = cu_model.as_sklearn()
+
+    roundtrip = cuml.preprocessing.LabelBinarizer.from_sklearn(sk_model2)
+    assert_roundtrip_consistency(cu_model, roundtrip)
+
+    np.testing.assert_array_equal(cu_model.classes_, sk_model2.classes_)
+    np.testing.assert_array_equal(cu_model.classes_, roundtrip.classes_)
+    assert roundtrip.y_type_ == cu_model.y_type_
+    assert roundtrip.sparse_input_ == cu_model.sparse_input_
+
+    sol = np.array([[1, 0, 0], [0, 1, 0], [0, 0, 1], [1, 0, 0]])
+    cu_out = cu_model2.transform(y)
+    sk_out = sk_model2.transform(y)
+
+    np.testing.assert_array_equal(cu_out, sol)
+    np.testing.assert_array_equal(sk_out, sol)

--- a/python/cuml/tests/test_validation.py
+++ b/python/cuml/tests/test_validation.py
@@ -950,15 +950,14 @@ def test_check_array_sparse_not_supported(array):
 def test_check_array_sparse_input(array, mem_type):
     ns = cp_sp if is_cuda_output(mem_type, array) else sp
     # dtype=None case
-    if (
-        mem_type == "device"
-        and array.dtype.kind != "f"
-        and array.format != "dia"
-    ):
-        # cupy only supports floating dtypes for these inputs. We let cupy
-        # itself raise an exception, we don't really care what it is.
-        with pytest.raises(ValueError, match="float32"):
-            check_array(array, accept_sparse=True, mem_type=mem_type)
+    if mem_type == "device" and array.dtype.kind != "f":
+        # coercing to device causes a dtype conversion even if dtype=None if
+        # the input is an unsupported type. In that case we chose the float
+        # type with the nearest itemsize.
+        out = check_array(array, accept_sparse=True, mem_type=mem_type)
+        coerced_dtype = "float32" if array.dtype.itemsize <= 4 else "float64"
+        assert ns.issparse(out)
+        assert out.dtype == coerced_dtype
     else:
         out = check_array(array, accept_sparse=True, mem_type=mem_type)
         assert ns.issparse(out)
@@ -970,6 +969,47 @@ def test_check_array_sparse_input(array, mem_type):
     )
     assert ns.issparse(out)
     assert out.dtype == "float32"
+
+
+def test_check_array_sparse_input_unsupported_dtype():
+    """Cupy doesn't support integral types while scipy does, this checks a few
+    edge cases for how we handle that"""
+    host_i2 = sp.rand(100, 100, density=0.5).astype("i2")
+    host_i4 = sp.rand(100, 100, density=0.5).astype("i4")
+    host_i8 = sp.rand(100, 100, density=0.5).astype("i8")
+    device_f4 = cp_sp.rand(100, 100, density=0.5).astype("f4")
+
+    # Unsupported dtypes are coerced to floats by default
+    for array in [host_i2, host_i4, host_i8]:
+        out = check_array(array, accept_sparse=True)
+        dtype = "f4" if array.dtype.itemsize <= 4 else "f8"
+        assert out.dtype == dtype
+
+    # Unsupported dtypes skipped when selecting conversion
+    out = check_array(host_i4, dtype=["i4", "f8", "f4"], accept_sparse=True)
+    assert out.dtype == "f8"
+
+    # When coercing host->host, ints are supported
+    out = check_array(host_i4, accept_sparse=True, mem_type=None)
+    assert out.dtype == "i4"
+    out = check_array(host_i2, dtype=["i4"], accept_sparse=True, mem_type=None)
+    assert out.dtype == "i4"
+
+    # When coercing device->host, ints are supported
+    out = check_array(
+        device_f4, dtype=["i4", "i8"], mem_type="host", accept_sparse=True
+    )
+    assert out.dtype == "i4"
+
+    # When coercing to device, error if only unsupported dtypes specified
+    with pytest.raises(ValueError, match="is supported by cupyx.scipy.sparse"):
+        check_array(host_i4, dtype=["i4", "i8"], accept_sparse=True)
+    with pytest.raises(ValueError, match="is supported by cupyx.scipy.sparse"):
+        check_array(device_f4, dtype=["i4", "i8"], accept_sparse=True)
+    with pytest.raises(ValueError, match="is supported by cupyx.scipy.sparse"):
+        check_array(
+            device_f4, mem_type=None, dtype=["i4", "i8"], accept_sparse=True
+        )
 
 
 @example(


### PR DESCRIPTION
- Updates `LabelBinarizer` to follow standard cuml and sklearn conventions (simple `__init__`, no mutation, type reflection, ...)
- Applies new validation
- Adds `sparse_input_` and `y_type_` attributes
- Improves validation and error messages
- Improves resilience and sklearn compatibility
- Improves test coverage
- Adds support for sklearn interop
- Adds support for cuml.accel
- Improves docstrings

This required one change to `cuml.internals.validation` around handling of unsupported dtypes for `cupyx.scipy.sparse`. This is split out into a separate commit with a new test case.

Part of #7317.
Fixes #8087. 