### PR TITLE
Expose fitted attributes for Dask linear models

### DIFF
--- a/python/cuml/cuml/dask/common/base.py
+++ b/python/cuml/cuml/dask/common/base.py
@@ -171,16 +171,19 @@ class BaseEstimator:
         previous_output_type = settings.output_type
         settings.output_type = output_type
         try:
-            if hasattr(model, name):
+            try:
                 return getattr(model, name)
-            # skip raising an error for ipython/jupyter related attributes
-            elif any([x in name for x in ("_ipython", "_repr")]):
-                pass
-            else:
-                raise AttributeError(
-                    "Attribute %s does not exist on model %s"
-                    % (name, type(model))
-                )
+            except AttributeError as e:
+                # skip raising an error for ipython/jupyter related attributes
+                if any([x in name for x in ("_ipython", "_repr")]):
+                    pass
+                elif e.name == name and e.obj is model:
+                    raise AttributeError(
+                        "Attribute %s does not exist on model %s"
+                        % (name, type(model))
+                    ) from e
+                else:
+                    raise
         finally:
             settings.output_type = previous_output_type
 

--- a/python/cuml/cuml/dask/common/base.py
+++ b/python/cuml/cuml/dask/common/base.py
@@ -20,6 +20,7 @@ from cuml.dask.common import parts_to_ranks
 from cuml.dask.common.input_utils import DistributedDataHandler
 from cuml.dask.common.utils import get_client, wait_and_raise_from_futures
 from cuml.internals.base import Base
+from cuml.internals.global_settings import GlobalSettings
 
 
 class BaseEstimator:
@@ -164,16 +165,24 @@ class BaseEstimator:
 
     @staticmethod
     @dask.delayed
-    def _get_model_attr(model, name):
-        if hasattr(model, name):
-            return getattr(model, name)
-        # skip raising an error for ipython/jupyter related attributes
-        elif any([x in name for x in ("_ipython", "_repr")]):
-            pass
-        else:
-            raise AttributeError(
-                "Attribute %s does not exist on model %s" % (name, type(model))
-            )
+    def _get_model_attr(model, name, output_type):
+        # Global settings are thread-local, so propagate the client's selection.
+        settings = GlobalSettings()
+        previous_output_type = settings.output_type
+        settings.output_type = output_type
+        try:
+            if hasattr(model, name):
+                return getattr(model, name)
+            # skip raising an error for ipython/jupyter related attributes
+            elif any([x in name for x in ("_ipython", "_repr")]):
+                pass
+            else:
+                raise AttributeError(
+                    "Attribute %s does not exist on model %s"
+                    % (name, type(model))
+                )
+        finally:
+            settings.output_type = previous_output_type
 
     def __getattr__(self, attr):
         """
@@ -212,7 +221,7 @@ class BaseEstimator:
                 # Otherwise, fetch the attribute from the distributed
                 # model and return it
                 ret_attr = BaseEstimator._get_model_attr(
-                    internal_model, attr
+                    internal_model, attr, GlobalSettings().output_type
                 ).compute()
         else:
             raise AttributeError(

--- a/python/cuml/cuml/dask/linear_model/elastic_net.py
+++ b/python/cuml/cuml/dask/linear_model/elastic_net.py
@@ -1,5 +1,5 @@
 #
-# SPDX-FileCopyrightText: Copyright (c) 2019-2026, NVIDIA CORPORATION.
+# SPDX-FileCopyrightText: Copyright (c) 2019-2026, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
 # SPDX-License-Identifier: Apache-2.0
 #
 
@@ -94,6 +94,18 @@ class ElasticNet(BaseEstimator):
         """
         self.solver.fit(X, y)
         return self
+
+    @property
+    def coef_(self):
+        return self.solver.coef_
+
+    @property
+    def intercept_(self):
+        return self.solver.intercept_
+
+    @property
+    def n_iter_(self):
+        return self.solver.n_iter_
 
     def predict(self, X, delayed=True):
         """

--- a/python/cuml/cuml/dask/linear_model/elastic_net.py
+++ b/python/cuml/cuml/dask/linear_model/elastic_net.py
@@ -95,17 +95,15 @@ class ElasticNet(BaseEstimator):
         self.solver.fit(X, y)
         return self
 
-    @property
-    def coef_(self):
-        return self.solver.coef_
-
-    @property
-    def intercept_(self):
-        return self.solver.intercept_
-
-    @property
-    def n_iter_(self):
-        return self.solver.n_iter_
+    def __getattr__(self, attr):
+        if attr in ("coef_", "intercept_", "n_iter_"):
+            try:
+                return getattr(self.solver, attr)
+            except AttributeError as e:
+                raise AttributeError(
+                    "%s is not fitted" % type(self).__name__
+                ) from e
+        return super().__getattr__(attr)
 
     def predict(self, X, delayed=True):
         """

--- a/python/cuml/cuml/dask/linear_model/lasso.py
+++ b/python/cuml/cuml/dask/linear_model/lasso.py
@@ -84,17 +84,15 @@ class Lasso(BaseEstimator):
 
         return self
 
-    @property
-    def coef_(self):
-        return self.solver.coef_
-
-    @property
-    def intercept_(self):
-        return self.solver.intercept_
-
-    @property
-    def n_iter_(self):
-        return self.solver.n_iter_
+    def __getattr__(self, attr):
+        if attr in ("coef_", "intercept_", "n_iter_"):
+            try:
+                return getattr(self.solver, attr)
+            except AttributeError as e:
+                raise AttributeError(
+                    "%s is not fitted" % type(self).__name__
+                ) from e
+        return super().__getattr__(attr)
 
     def predict(self, X, delayed=True):
         """

--- a/python/cuml/cuml/dask/linear_model/lasso.py
+++ b/python/cuml/cuml/dask/linear_model/lasso.py
@@ -1,5 +1,5 @@
 #
-# SPDX-FileCopyrightText: Copyright (c) 2020-2025, NVIDIA CORPORATION.
+# SPDX-FileCopyrightText: Copyright (c) 2020-2026, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
 # SPDX-License-Identifier: Apache-2.0
 #
 
@@ -83,6 +83,18 @@ class Lasso(BaseEstimator):
         self.solver.fit(X, y)
 
         return self
+
+    @property
+    def coef_(self):
+        return self.solver.coef_
+
+    @property
+    def intercept_(self):
+        return self.solver.intercept_
+
+    @property
+    def n_iter_(self):
+        return self.solver.n_iter_
 
     def predict(self, X, delayed=True):
         """

--- a/python/cuml/cuml/dask/linear_model/ridge.py
+++ b/python/cuml/cuml/dask/linear_model/ridge.py
@@ -1,4 +1,4 @@
-# SPDX-FileCopyrightText: Copyright (c) 2019-2025, NVIDIA CORPORATION.
+# SPDX-FileCopyrightText: Copyright (c) 2019-2026, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
 # SPDX-License-Identifier: Apache-2.0
 #
 
@@ -50,8 +50,6 @@ class Ridge(BaseEstimator, SyncFitMixinLinearModel, DelayedPredictionMixin):
     def __init__(self, *, client=None, verbose=False, **kwargs):
         super().__init__(client=client, verbose=verbose, **kwargs)
 
-        self.coef_ = None
-        self.intercept_ = None
         self._model_fit = False
         self._consec_call = 0
 

--- a/python/cuml/tests/dask/test_dask_base.py
+++ b/python/cuml/tests/dask/test_dask_base.py
@@ -1,4 +1,4 @@
-# SPDX-FileCopyrightText: Copyright (c) 2020-2026, NVIDIA CORPORATION.
+# SPDX-FileCopyrightText: Copyright (c) 2020-2026, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
 # SPDX-License-Identifier: Apache-2.0
 #
 

--- a/python/cuml/tests/dask/test_dask_base.py
+++ b/python/cuml/tests/dask/test_dask_base.py
@@ -17,6 +17,7 @@ from sklearn.model_selection import train_test_split
 
 import cuml
 from cuml.dask.cluster import KMeans
+from cuml.dask.common.base import BaseEstimator
 from cuml.dask.common.input_utils import DistributedDataHandler
 from cuml.dask.datasets import make_blobs, make_regression
 from cuml.dask.linear_model import LinearRegression
@@ -169,6 +170,32 @@ def test_getattr(client):
 
     assert nb_model.feature_count_ is not None
     assert isinstance(nb_model.feature_count_, cupy.ndarray)
+
+
+def test_get_model_attr_chains_missing_attribute_error():
+    class Model:
+        pass
+
+    with pytest.raises(
+        AttributeError, match="does not exist on model"
+    ) as error:
+        BaseEstimator._get_model_attr(
+            Model(), "fitted_attribute", None
+        ).compute()
+
+    assert error.value.__cause__ is not None
+
+
+def test_get_model_attr_preserves_attribute_resolution_error():
+    class Model:
+        @property
+        def fitted_attribute(self):
+            raise AttributeError("attribute resolution failed")
+
+    with pytest.raises(AttributeError, match="attribute resolution failed"):
+        BaseEstimator._get_model_attr(
+            Model(), "fitted_attribute", None
+        ).compute()
 
 
 def _make_dask_data_with_empty_worker(client):

--- a/python/cuml/tests/dask/test_dask_coordinate_descent.py
+++ b/python/cuml/tests/dask/test_dask_coordinate_descent.py
@@ -4,10 +4,49 @@
 import numpy as np
 import pytest
 
+import cuml
 from cuml.dask.datasets import make_regression
 from cuml.dask.linear_model import ElasticNet, Lasso
 from cuml.metrics import r2_score
-from cuml.testing.utils import quality_param, stress_param, unit_param
+from cuml.testing.utils import (
+    as_numpy,
+    quality_param,
+    stress_param,
+    unit_param,
+)
+
+
+def _as_numpy_array(value):
+    return np.asarray(as_numpy(value))
+
+
+def _assert_cd_fitted_attrs_match_solver(model, dtype):
+    coef = model.coef_
+    intercept = model.intercept_
+    n_iter = model.n_iter_
+    solver_coef = model.solver.coef_
+    solver_intercept = model.solver.intercept_
+
+    coef_np = _as_numpy_array(coef)
+    intercept_np = _as_numpy_array(intercept)
+
+    assert coef is not None
+    assert intercept is not None
+    assert n_iter is not None
+    assert coef_np.dtype == dtype
+    if not np.isscalar(intercept):
+        assert intercept_np.dtype == dtype
+    assert coef_np.shape == (20,)
+    assert intercept_np.shape in ((), (1,))
+    assert isinstance(n_iter, (int, np.integer))
+    np.testing.assert_allclose(coef_np, _as_numpy_array(solver_coef))
+    np.testing.assert_allclose(intercept_np, _as_numpy_array(solver_intercept))
+    assert n_iter == model.solver.n_iter_
+
+    with cuml.using_output_type("numpy"):
+        assert isinstance(model.coef_, np.ndarray)
+        np.testing.assert_allclose(model.coef_, model.solver.coef_)
+        np.testing.assert_allclose(model.intercept_, model.solver.intercept_)
 
 
 @pytest.mark.mg
@@ -222,17 +261,17 @@ def test_cd_fitted_attributes(cls, dtype, client):
         dtype=dtype,
     )
 
-    model = cls(max_iter=2, client=client)
+    model = cls(alpha=np.array([0.001]), max_iter=2, client=client)
     for attr in ("coef_", "intercept_", "n_iter_"):
         with pytest.raises(AttributeError):
             getattr(model, attr)
 
     model.fit(X, y)
 
-    assert model.coef_ is not None
-    assert model.intercept_ is not None
-    assert model.n_iter_ is not None
-    assert model.coef_.shape == model.solver.coef_.shape
-    assert type(model.coef_) is type(model.solver.coef_)
-    assert type(model.intercept_) is type(model.solver.intercept_)
-    assert model.n_iter_ == model.solver.n_iter_
+    _assert_cd_fitted_attrs_match_solver(model, dtype)
+    first_coef = _as_numpy_array(model.coef_).copy()
+
+    model.fit(X, -y)
+
+    _assert_cd_fitted_attrs_match_solver(model, dtype)
+    assert not np.allclose(_as_numpy_array(model.coef_), first_coef)

--- a/python/cuml/tests/dask/test_dask_coordinate_descent.py
+++ b/python/cuml/tests/dask/test_dask_coordinate_descent.py
@@ -8,6 +8,7 @@ import pytest
 import cuml
 from cuml.dask.datasets import make_regression
 from cuml.dask.linear_model import ElasticNet, Lasso
+from cuml.internals.global_settings import GlobalSettings
 from cuml.metrics import r2_score
 from cuml.testing.utils import (
     as_numpy,
@@ -44,11 +45,13 @@ def _assert_cd_fitted_attrs_match_solver(model, dtype):
     np.testing.assert_allclose(intercept_np, _as_numpy_array(solver_intercept))
     assert n_iter == model.solver.n_iter_
 
+    previous_output_type = GlobalSettings().output_type
     with cuml.using_output_type("numpy"):
         assert isinstance(model.coef_, np.ndarray)
         assert np.isscalar(model.intercept_)
         np.testing.assert_allclose(model.coef_, model.solver.coef_)
         np.testing.assert_allclose(model.intercept_, model.solver.intercept_)
+    assert GlobalSettings().output_type == previous_output_type
 
 
 @pytest.mark.mg
@@ -285,6 +288,9 @@ def test_cd_fitted_attributes(cls, dtype, client):
             getattr(model, attr)
 
     model.fit(X, y)
+
+    with pytest.raises(AttributeError):
+        model.attribute_that_does_not_exist_
 
     _assert_cd_fitted_attrs_match_solver(model, dtype)
     first_coef = _as_numpy_array(model.coef_).copy()

--- a/python/cuml/tests/dask/test_dask_coordinate_descent.py
+++ b/python/cuml/tests/dask/test_dask_coordinate_descent.py
@@ -1,4 +1,4 @@
-# SPDX-FileCopyrightText: Copyright (c) 2020-2026, NVIDIA CORPORATION.
+# SPDX-FileCopyrightText: Copyright (c) 2020-2026, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
 # SPDX-License-Identifier: Apache-2.0
 #
 import numpy as np
@@ -207,3 +207,32 @@ def test_max_iter_n_iter(cls, client):
 
     model = cls(max_iter=2, client=client).fit(X, y)
     assert model.solver.n_iter_ == 2
+    assert model.n_iter_ == model.solver.n_iter_
+
+
+@pytest.mark.parametrize("cls", [ElasticNet, Lasso])
+@pytest.mark.parametrize("dtype", [np.float32, np.float64])
+def test_cd_fitted_attributes(cls, dtype, client):
+    X, y = make_regression(
+        n_samples=500,
+        n_features=20,
+        n_parts=10,
+        n_informative=10,
+        client=client,
+        dtype=dtype,
+    )
+
+    model = cls(max_iter=2, client=client)
+    for attr in ("coef_", "intercept_", "n_iter_"):
+        with pytest.raises(AttributeError):
+            getattr(model, attr)
+
+    model.fit(X, y)
+
+    assert model.coef_ is not None
+    assert model.intercept_ is not None
+    assert model.n_iter_ is not None
+    assert model.coef_.shape == model.solver.coef_.shape
+    assert type(model.coef_) is type(model.solver.coef_)
+    assert type(model.intercept_) is type(model.solver.intercept_)
+    assert model.n_iter_ == model.solver.n_iter_

--- a/python/cuml/tests/dask/test_dask_coordinate_descent.py
+++ b/python/cuml/tests/dask/test_dask_coordinate_descent.py
@@ -28,19 +28,17 @@ def _assert_cd_fitted_attrs_match_solver(model, dtype):
     solver_coef = model.solver.coef_
     solver_intercept = model.solver.intercept_
 
-    coef_np = _as_numpy_array(coef)
-    intercept_np = _as_numpy_array(intercept)
-
     assert coef is not None
     assert intercept is not None
     assert n_iter is not None
     assert isinstance(coef, cp.ndarray)
     assert np.isscalar(intercept)
+
+    coef_np = _as_numpy_array(coef)
+    intercept_np = _as_numpy_array(intercept)
+
     assert coef_np.dtype == dtype
-    if not np.isscalar(intercept):
-        assert intercept_np.dtype == dtype
     assert coef_np.shape == (20,)
-    assert intercept_np.shape in ((), (1,))
     assert isinstance(n_iter, (int, np.integer))
     np.testing.assert_allclose(coef_np, _as_numpy_array(solver_coef))
     np.testing.assert_allclose(intercept_np, _as_numpy_array(solver_intercept))
@@ -48,6 +46,7 @@ def _assert_cd_fitted_attrs_match_solver(model, dtype):
 
     with cuml.using_output_type("numpy"):
         assert isinstance(model.coef_, np.ndarray)
+        assert np.isscalar(model.intercept_)
         np.testing.assert_allclose(model.coef_, model.solver.coef_)
         np.testing.assert_allclose(model.intercept_, model.solver.intercept_)
 

--- a/python/cuml/tests/dask/test_dask_coordinate_descent.py
+++ b/python/cuml/tests/dask/test_dask_coordinate_descent.py
@@ -252,6 +252,22 @@ def test_max_iter_n_iter(cls, client):
 
 
 @pytest.mark.parametrize("cls", [ElasticNet, Lasso])
+@pytest.mark.parametrize("attr", ["coef_", "intercept_", "n_iter_"])
+def test_cd_fitted_attributes_require_fit(cls, attr, client):
+    model = cls(client=client)
+
+    with pytest.raises(AttributeError, match="not fitted") as error:
+        getattr(model, attr)
+
+    assert error.value.__cause__ is not None
+
+
+@pytest.mark.parametrize("cls", [ElasticNet, Lasso])
+def test_cd_fitted_attributes_are_absent_before_fit(cls, client):
+    assert not hasattr(cls(client=client), "coef_")
+
+
+@pytest.mark.parametrize("cls", [ElasticNet, Lasso])
 @pytest.mark.parametrize("dtype", [np.float32, np.float64])
 def test_cd_fitted_attributes(cls, dtype, client):
     X, y = make_regression(

--- a/python/cuml/tests/dask/test_dask_coordinate_descent.py
+++ b/python/cuml/tests/dask/test_dask_coordinate_descent.py
@@ -1,6 +1,7 @@
 # SPDX-FileCopyrightText: Copyright (c) 2020-2026, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
 # SPDX-License-Identifier: Apache-2.0
 #
+import cupy as cp
 import numpy as np
 import pytest
 
@@ -33,6 +34,8 @@ def _assert_cd_fitted_attrs_match_solver(model, dtype):
     assert coef is not None
     assert intercept is not None
     assert n_iter is not None
+    assert isinstance(coef, cp.ndarray)
+    assert np.isscalar(intercept)
     assert coef_np.dtype == dtype
     if not np.isscalar(intercept):
         assert intercept_np.dtype == dtype
@@ -261,7 +264,7 @@ def test_cd_fitted_attributes(cls, dtype, client):
         dtype=dtype,
     )
 
-    model = cls(alpha=np.array([0.001]), max_iter=2, client=client)
+    model = cls(alpha=np.array([0.001]), max_iter=2, tol=0.0, client=client)
     for attr in ("coef_", "intercept_", "n_iter_"):
         with pytest.raises(AttributeError):
             getattr(model, attr)
@@ -270,8 +273,13 @@ def test_cd_fitted_attributes(cls, dtype, client):
 
     _assert_cd_fitted_attrs_match_solver(model, dtype)
     first_coef = _as_numpy_array(model.coef_).copy()
+    first_n_iter = model.n_iter_
+    assert first_n_iter == 2
 
+    model.solver.kwargs["max_iter"] = 3
     model.fit(X, -y)
 
     _assert_cd_fitted_attrs_match_solver(model, dtype)
     assert not np.allclose(_as_numpy_array(model.coef_), first_coef)
+    assert model.n_iter_ == 3
+    assert model.n_iter_ != first_n_iter

--- a/python/cuml/tests/dask/test_dask_ridge_regression.py
+++ b/python/cuml/tests/dask/test_dask_ridge_regression.py
@@ -27,34 +27,26 @@ def _assert_ridge_fitted_attrs_match_model(
     coef = model.coef_
     intercept = model.intercept_
 
-    coef_np = _as_numpy_array(coef)
-    intercept_np = _as_numpy_array(intercept)
-
     assert coef is not None
     assert intercept is not None
     assert isinstance(coef, cudf.Series)
+    assert np.isscalar(intercept)
+
+    coef_np = _as_numpy_array(coef)
+
     assert coef_np.dtype == datatype
     assert coef_np.shape == (ncols,)
     np.testing.assert_allclose(coef_np, _as_numpy_array(internal_model.coef_))
-    np.testing.assert_allclose(
-        intercept_np, _as_numpy_array(internal_model.intercept_)
-    )
+    assert intercept == internal_model.intercept_
 
-    if fit_intercept:
-        assert isinstance(intercept, cudf.Series)
-        assert intercept_np.dtype == datatype
-        assert intercept_np.shape == (1,)
-    else:
-        assert np.isscalar(intercept)
-        assert intercept_np.shape == ()
-        assert intercept_np.item() == 0.0
+    if not fit_intercept:
+        assert intercept == 0.0
 
     with cuml.using_output_type("numpy"):
         assert isinstance(model.coef_, np.ndarray)
+        assert np.isscalar(model.intercept_)
         np.testing.assert_allclose(model.coef_, internal_model.coef_)
-        np.testing.assert_allclose(model.intercept_, internal_model.intercept_)
-        if fit_intercept:
-            assert isinstance(model.intercept_, np.ndarray)
+        assert model.intercept_ == internal_model.intercept_
 
 
 def _prep_training_data(c, X_train, y_train, partitions_per_worker):

--- a/python/cuml/tests/dask/test_dask_ridge_regression.py
+++ b/python/cuml/tests/dask/test_dask_ridge_regression.py
@@ -32,6 +32,7 @@ def _assert_ridge_fitted_attrs_match_model(
 
     assert coef is not None
     assert intercept is not None
+    assert isinstance(coef, cudf.Series)
     assert coef_np.dtype == datatype
     assert coef_np.shape == (ncols,)
     np.testing.assert_allclose(coef_np, _as_numpy_array(internal_model.coef_))
@@ -40,9 +41,11 @@ def _assert_ridge_fitted_attrs_match_model(
     )
 
     if fit_intercept:
+        assert isinstance(intercept, cudf.Series)
         assert intercept_np.dtype == datatype
         assert intercept_np.shape == (1,)
     else:
+        assert np.isscalar(intercept)
         assert intercept_np.shape == ()
         assert intercept_np.item() == 0.0
 

--- a/python/cuml/tests/dask/test_dask_ridge_regression.py
+++ b/python/cuml/tests/dask/test_dask_ridge_regression.py
@@ -1,4 +1,4 @@
-# SPDX-FileCopyrightText: Copyright (c) 2019-2025, NVIDIA CORPORATION.
+# SPDX-FileCopyrightText: Copyright (c) 2019-2026, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
 # SPDX-License-Identifier: Apache-2.0
 #
 
@@ -62,8 +62,20 @@ def test_ridge(
     X_df, y_df = _prep_training_data(client, X, y, n_parts)
 
     lr = cumlRidge_dask(alpha=0.5, fit_intercept=fit_intercept)
+    for attr in ("coef_", "intercept_"):
+        with pytest.raises(AttributeError):
+            getattr(lr, attr)
 
     lr.fit(X_df, y_df)
+
+    internal_model = lr.get_combined_model()
+    assert lr.coef_ is not None
+    assert lr.intercept_ is not None
+    assert lr.coef_.shape == internal_model.coef_.shape
+    if hasattr(lr.intercept_, "shape"):
+        assert lr.intercept_.shape == internal_model.intercept_.shape
+    assert type(lr.coef_) is type(internal_model.coef_)
+    assert type(lr.intercept_) is type(internal_model.intercept_)
 
     ret = lr.predict(X_df, delayed=delayed)
 

--- a/python/cuml/tests/dask/test_dask_ridge_regression.py
+++ b/python/cuml/tests/dask/test_dask_ridge_regression.py
@@ -10,9 +10,48 @@ import pytest
 from sklearn.datasets import make_regression
 from sklearn.metrics import mean_squared_error
 
+import cuml
 from cuml.dask.common import utils as dask_utils
+from cuml.testing.utils import as_numpy
 
 pytestmark = pytest.mark.mg
+
+
+def _as_numpy_array(value):
+    return np.asarray(as_numpy(value))
+
+
+def _assert_ridge_fitted_attrs_match_model(
+    model, internal_model, datatype, ncols, fit_intercept
+):
+    coef = model.coef_
+    intercept = model.intercept_
+
+    coef_np = _as_numpy_array(coef)
+    intercept_np = _as_numpy_array(intercept)
+
+    assert coef is not None
+    assert intercept is not None
+    assert coef_np.dtype == datatype
+    assert coef_np.shape == (ncols,)
+    np.testing.assert_allclose(coef_np, _as_numpy_array(internal_model.coef_))
+    np.testing.assert_allclose(
+        intercept_np, _as_numpy_array(internal_model.intercept_)
+    )
+
+    if fit_intercept:
+        assert intercept_np.dtype == datatype
+        assert intercept_np.shape == (1,)
+    else:
+        assert intercept_np.shape == ()
+        assert intercept_np.item() == 0.0
+
+    with cuml.using_output_type("numpy"):
+        assert isinstance(model.coef_, np.ndarray)
+        np.testing.assert_allclose(model.coef_, internal_model.coef_)
+        np.testing.assert_allclose(model.intercept_, internal_model.intercept_)
+        if fit_intercept:
+            assert isinstance(model.intercept_, np.ndarray)
 
 
 def _prep_training_data(c, X_train, y_train, partitions_per_worker):
@@ -69,16 +108,38 @@ def test_ridge(
     lr.fit(X_df, y_df)
 
     internal_model = lr.get_combined_model()
-    assert lr.coef_ is not None
-    assert lr.intercept_ is not None
-    assert lr.coef_.shape == internal_model.coef_.shape
-    if hasattr(lr.intercept_, "shape"):
-        assert lr.intercept_.shape == internal_model.intercept_.shape
-    assert type(lr.coef_) is type(internal_model.coef_)
-    assert type(lr.intercept_) is type(internal_model.intercept_)
+    _assert_ridge_fitted_attrs_match_model(
+        lr, internal_model, datatype, ncols, fit_intercept
+    )
 
     ret = lr.predict(X_df, delayed=delayed)
 
     error_cuml = mean_squared_error(y, ret.compute().to_pandas().values)
 
     assert error_cuml < 1e-1
+
+
+@pytest.mark.parametrize("fit_intercept", [False, True])
+@pytest.mark.parametrize("datatype", [np.float32, np.float64])
+def test_ridge_fitted_attributes_follow_refit(fit_intercept, datatype, client):
+    from cuml.dask.linear_model import Ridge as cumlRidge_dask
+
+    nrows = 500
+    ncols = 10
+    X, y = make_regression_dataset(datatype, nrows, ncols, n_info=5)
+    X_df, y_df = _prep_training_data(client, X, y, partitions_per_worker=2)
+
+    model = cumlRidge_dask(alpha=0.5, fit_intercept=fit_intercept)
+    model.fit(X_df, y_df)
+    _assert_ridge_fitted_attrs_match_model(
+        model, model.get_combined_model(), datatype, ncols, fit_intercept
+    )
+    first_coef = _as_numpy_array(model.coef_).copy()
+
+    refit_y_df = -y_df
+    model.fit(X_df, refit_y_df)
+
+    _assert_ridge_fitted_attrs_match_model(
+        model, model.get_combined_model(), datatype, ncols, fit_intercept
+    )
+    assert not np.allclose(_as_numpy_array(model.coef_), first_coef)

--- a/python/cuml/tests/dask/test_dask_ridge_regression.py
+++ b/python/cuml/tests/dask/test_dask_ridge_regression.py
@@ -12,6 +12,7 @@ from sklearn.metrics import mean_squared_error
 
 import cuml
 from cuml.dask.common import utils as dask_utils
+from cuml.internals.global_settings import GlobalSettings
 from cuml.testing.utils import as_numpy
 
 pytestmark = pytest.mark.mg
@@ -42,11 +43,13 @@ def _assert_ridge_fitted_attrs_match_model(
     if not fit_intercept:
         assert intercept == 0.0
 
+    previous_output_type = GlobalSettings().output_type
     with cuml.using_output_type("numpy"):
         assert isinstance(model.coef_, np.ndarray)
         assert np.isscalar(model.intercept_)
         np.testing.assert_allclose(model.coef_, internal_model.coef_)
         assert model.intercept_ == internal_model.intercept_
+    assert GlobalSettings().output_type == previous_output_type
 
 
 def _prep_training_data(c, X_train, y_train, partitions_per_worker):
@@ -101,6 +104,9 @@ def test_ridge(
             getattr(lr, attr)
 
     lr.fit(X_df, y_df)
+
+    with pytest.raises(AttributeError):
+        lr.attribute_that_does_not_exist_
 
     internal_model = lr.get_combined_model()
     _assert_ridge_fitted_attrs_match_model(


### PR DESCRIPTION
## Summary

- Expose `coef_`, `intercept_`, and `n_iter_` from Dask ElasticNet and Lasso.
- Let Dask Ridge proxy `coef_` and `intercept_` from its fitted model.
- Carry the client output type when a fitted attribute is read from a worker.
- Add coverage for pre-fit errors, output types, and refits.

## Testing

- Changed-file pre-commit checks pass.
- The new Dask tests cover ElasticNet, Lasso, and Ridge.

Addresses #7460
