### PR TITLE
Validate precomputed pairwise kernel shapes

### DIFF
--- a/python/cuml/cuml/metrics/pairwise_kernels.py
+++ b/python/cuml/cuml/metrics/pairwise_kernels.py
@@ -214,10 +214,11 @@ def pairwise_kernels(
         ndarray, cuda array interface compliant array like CuPy.
     Y : array-like (device or host) of shape (n_samples_Y, n_features), \
         default=None
-        A second feature array only if X has shape (n_samples_X, n_features).
-        For metric == "precomputed", only Y.shape[0] is used to validate the
-        shape of X; the values and second dimension of Y do not affect the
-        returned matrix.
+        For metrics other than "precomputed", a second feature array only if X
+        has shape (n_samples_X, n_features). For metric == "precomputed", Y
+        can be any 2D array; only Y.shape[0] is used to validate the shape of X,
+        and the values and second dimension of Y do not affect the returned
+        matrix.
         Acceptable formats: cuDF DataFrame, NumPy ndarray, Numba device
         ndarray, cuda array interface compliant array like CuPy.
     metric : str or callable (numba device function), default="linear"

--- a/python/cuml/cuml/metrics/pairwise_kernels.py
+++ b/python/cuml/cuml/metrics/pairwise_kernels.py
@@ -283,11 +283,17 @@ def pairwise_kernels(
         Y = X
     else:
         Y = check_array(Y, input_name="Y")
+    if metric == "precomputed":
+        if X.shape[1] != Y.shape[0]:
+            raise ValueError(
+                "Precomputed metric requires shape "
+                "(n_queries, n_indexed). "
+                f"Got {X.shape} for {Y.shape[0]} indexed."
+            )
+        return X
+
     if X.shape[1] != Y.shape[1]:
         raise ValueError("X and Y have different dimensions.")
-
-    if metric == "precomputed":
-        return X
 
     if metric in PAIRWISE_KERNEL_FUNCTIONS:
         kwds = _filter_params(

--- a/python/cuml/cuml/metrics/pairwise_kernels.py
+++ b/python/cuml/cuml/metrics/pairwise_kernels.py
@@ -206,12 +206,18 @@ def pairwise_kernels(
             (n_samples_X, n_features)
         Array of pairwise kernels between samples, or a feature array.
         The shape of the array should be (n_samples_X, n_samples_X) if
-        metric == "precomputed" and (n_samples_X, n_features) otherwise.
+        metric == "precomputed" and Y is None. If Y is provided with
+        metric == "precomputed", X should have shape (n_queries, n_indexed),
+        where n_indexed must equal Y.shape[0]. Otherwise, X should have shape
+        (n_samples_X, n_features).
         Acceptable formats: cuDF DataFrame, NumPy ndarray, Numba device
         ndarray, cuda array interface compliant array like CuPy.
     Y : array-like (device or host) of shape (n_samples_Y, n_features), \
         default=None
         A second feature array only if X has shape (n_samples_X, n_features).
+        For metric == "precomputed", only Y.shape[0] is used to validate the
+        shape of X; the values and second dimension of Y do not affect the
+        returned matrix.
         Acceptable formats: cuDF DataFrame, NumPy ndarray, Numba device
         ndarray, cuda array interface compliant array like CuPy.
     metric : str or callable (numba device function), default="linear"
@@ -245,7 +251,9 @@ def pairwise_kernels(
 
     Notes
     -----
-    If metric is 'precomputed', Y is ignored and X is returned.
+    If metric is 'precomputed', Y is only used to validate the shape of X:
+    X must be square when Y is None, or X.shape[1] must equal Y.shape[0]
+    otherwise. X is returned unchanged.
 
     Examples
     --------

--- a/python/cuml/tests/test_kernel_ridge.py
+++ b/python/cuml/tests/test_kernel_ridge.py
@@ -107,6 +107,31 @@ def test_pairwise_kernels_basic():
     assert np.allclose(X, pairwise_kernels(X, metric="precomputed"))
 
 
+@pytest.mark.parametrize("shape", [(5, 3), (3, 5)])
+def test_pairwise_kernels_precomputed_requires_square(shape):
+    X = np.ones(shape)
+
+    with pytest.raises(ValueError, match="Precomputed metric requires shape"):
+        pairwise_kernels(X, metric="precomputed")
+
+
+def test_pairwise_kernels_precomputed_cross_kernel():
+    X = np.arange(6).reshape(3, 2)
+    Y = np.ones((2, 10))
+
+    result = pairwise_kernels(X, Y, metric="precomputed")
+
+    cp.testing.assert_array_equal(result, cp.asarray(X))
+
+
+def test_pairwise_kernels_precomputed_wrong_indexed_count():
+    X = np.ones((3, 4))
+    Y = np.ones((2, 10))
+
+    with pytest.raises(ValueError, match="Precomputed metric requires shape"):
+        pairwise_kernels(X, Y, metric="precomputed")
+
+
 @cuda.jit(device=True)
 def custom_kernel(x, y, custom_arg=5.0):
     sum = 0.0

--- a/python/cuml/tests/test_kernel_ridge.py
+++ b/python/cuml/tests/test_kernel_ridge.py
@@ -132,6 +132,14 @@ def test_pairwise_kernels_precomputed_wrong_indexed_count():
         pairwise_kernels(X, Y, metric="precomputed")
 
 
+def test_pairwise_kernels_rejects_mismatched_feature_dimensions():
+    X = np.ones((3, 4))
+    Y = np.ones((2, 5))
+
+    with pytest.raises(ValueError, match="X and Y have different dimensions."):
+        pairwise_kernels(X, Y, metric="linear")
+
+
 @cuda.jit(device=True)
 def custom_kernel(x, y, custom_arg=5.0):
     sum = 0.0

--- a/python/cuml/tests/test_kernel_ridge.py
+++ b/python/cuml/tests/test_kernel_ridge.py
@@ -136,7 +136,9 @@ def test_pairwise_kernels_rejects_mismatched_feature_dimensions():
     X = np.ones((3, 4))
     Y = np.ones((2, 5))
 
-    with pytest.raises(ValueError, match="X and Y have different dimensions."):
+    with pytest.raises(
+        ValueError, match=r"X and Y have different dimensions\."
+    ):
         pairwise_kernels(X, Y, metric="linear")
 
 


### PR DESCRIPTION
## Summary

- Validate that precomputed self-kernels are square.
- Validate that precomputed cross-kernels have matching indexed-sample counts.
- Add regression coverage for valid and invalid precomputed shapes.

The previous validation compared feature widths before recognizing `metric="precomputed"`, allowing malformed kernel matrices through or rejecting valid cross-kernel shapes with misleading errors.

## Testing

- `pre-commit run --files python/cuml/cuml/metrics/pairwise_kernels.py python/cuml/tests/test_kernel_ridge.py`
- `python3 -m py_compile python/cuml/cuml/metrics/pairwise_kernels.py python/cuml/tests/test_kernel_ridge.py`