### PR TITLE
Raise NotFittedError from unfitted IsolationForest methods

### DIFF
--- a/python/cuml/cuml/ensemble/isolation_forest.pyx
+++ b/python/cuml/cuml/ensemble/isolation_forest.pyx
@@ -18,6 +18,7 @@ import cupy as cp
 import numpy as np
 import nvforest
 import treelite
+from sklearn.exceptions import NotFittedError
 
 from cuml.internals.base import Base, get_handle
 from cuml.internals.interop import (
@@ -797,7 +798,7 @@ class IsolationForest(InteropMixin, CMajorInputTagMixin, Base):
         treelite.Model
         """
         if self._treelite_model_bytes is None:
-            raise RuntimeError("Model has not been fitted. Call fit() first.")
+            raise NotFittedError("Model has not been fitted. Call fit() first.")
 
         return treelite.Model.deserialize_bytes(self._treelite_model_bytes)
 
@@ -813,7 +814,7 @@ class IsolationForest(InteropMixin, CMajorInputTagMixin, Base):
             A forest inference model that predicts average path length.
         """
         if self._treelite_model_bytes is None:
-            raise RuntimeError("Model has not been fitted. Call fit() first.")
+            raise NotFittedError("Model has not been fitted. Call fit() first.")
 
         return nvforest.load_from_treelite_model(
             tl_model=treelite.Model.deserialize_bytes(self._treelite_model_bytes),
@@ -859,7 +860,7 @@ class IsolationForest(InteropMixin, CMajorInputTagMixin, Base):
         scoring path.
         """
         if self._treelite_model_bytes is None:
-            raise RuntimeError("Model has not been fitted. Call fit() first.")
+            raise NotFittedError("Model has not been fitted. Call fit() first.")
 
         X_m = check_inputs(
             self,
@@ -913,7 +914,7 @@ class IsolationForest(InteropMixin, CMajorInputTagMixin, Base):
         """
         cdef _IsolationForestModel model = self._model
         if model is None:
-            raise RuntimeError("Model has not been fitted. Call fit() first.")
+            raise NotFittedError("Model has not been fitted. Call fit() first.")
 
         # Convert input to a row-major device array for inference.
         X_m = check_inputs(
@@ -1003,7 +1004,7 @@ class IsolationForest(InteropMixin, CMajorInputTagMixin, Base):
         """
         cdef _IsolationForestModel model = self._model
         if model is None:
-            raise RuntimeError("Model has not been fitted. Call fit() first.")
+            raise NotFittedError("Model has not been fitted. Call fit() first.")
 
         # Convert input to a row-major device array for inference.
         X_m = check_inputs(

--- a/python/cuml/cuml/ensemble/isolation_forest.pyx
+++ b/python/cuml/cuml/ensemble/isolation_forest.pyx
@@ -367,15 +367,6 @@ _UNFITTED_BASELINE = {
     "_n_features_per_tree": None,
 }
 
-# Attributes that only exist on a fitted estimator.
-_FITTED_ONLY_ATTRS = (
-    "n_features_in_",
-    "feature_names_in_",
-    "max_samples_",
-    "offset_",
-    "_n_samples_per_tree",
-)
-
 
 class IsolationForest(InteropMixin, CMajorInputTagMixin, Base):
     """
@@ -577,18 +568,6 @@ class IsolationForest(InteropMixin, CMajorInputTagMixin, Base):
             "Conversion of a fitted cuML IsolationForest is not supported"
         )
 
-    @staticmethod
-    def _clear_fitted_state(state):
-        """Applies the unfitted baseline to the ``state`` mapping in place."""
-        state.update(_UNFITTED_BASELINE)
-        for attr in _FITTED_ONLY_ATTRS:
-            state.pop(attr, None)
-        return state
-
-    def _reset_fitted_state(self):
-        """Returns the estimator to its unfitted construction state."""
-        self._clear_fitted_state(self.__dict__)
-
     def __getstate__(self):
         """Pickle support: the native model cannot be serialized, so the
         fitted state is dropped entirely and the unpickled estimator is
@@ -600,7 +579,13 @@ class IsolationForest(InteropMixin, CMajorInputTagMixin, Base):
                 "state. The unpickled estimator is unfitted; call fit() "
                 "again before using it."
             )
-        return self._clear_fitted_state(state)
+        state.update(_UNFITTED_BASELINE)
+        # Fitted attributes follow the sklearn naming convention.
+        for attr in list(state):
+            if attr.endswith("_") and not attr.startswith("_"):
+                del state[attr]
+        state.pop("_n_samples_per_tree", None)
+        return state
 
     def __setstate__(self, state):
         """Pickle support - restore state."""
@@ -631,22 +616,138 @@ class IsolationForest(InteropMixin, CMajorInputTagMixin, Base):
         if sample_weight is not None:
             raise UnsupportedOnGPU("`sample_weight` is not supported")
 
-        # Drop any previous fitted state up front, so that a failed fit
-        # leaves the estimator unfitted rather than half fitted.
-        self._reset_fitted_state()
+        # Release any existing native model.
+        self._model = None
 
-        cdef size_t n_rows
-        cdef int n_cols
-        cdef uintptr_t X_ptr
+        # Convert input to a column-major device array for fit.
+        X_m = check_inputs(
+            self,
+            X,
+            dtype=(np.float32, np.float64),
+            order="F",
+            reset=True,
+        )
+
+        cdef size_t n_rows = X_m.shape[0]
+        cdef int n_cols = X_m.shape[1]
+        cdef uintptr_t X_ptr = X_m.data.ptr
         cdef double contamination_fraction = 0.0
         cdef bint use_contamination_quantile = False
+        self.n_features_in_ = n_cols
+        self._dtype = X_m.dtype
+
         cdef int actual_max_features
+        if isinstance(self.max_features, builtins.bool):
+            raise ValueError(
+                "max_features must be an int in [1, n_features] or a float "
+                "in (0.0, 1.0]."
+            )
+        elif isinstance(self.max_features, Integral):
+            if self.max_features < 1 or self.max_features > n_cols:
+                raise ValueError(
+                    "max_features must be an int in [1, n_features] or a "
+                    "float in (0.0, 1.0]."
+                )
+            actual_max_features = int(self.max_features)
+        elif isinstance(self.max_features, Real):
+            if self.max_features <= 0.0 or self.max_features > 1.0:
+                raise ValueError(
+                    "max_features must be an int in [1, n_features] or a "
+                    "float in (0.0, 1.0]."
+                )
+            actual_max_features = max(1, int(self.max_features * n_cols))
+        else:
+            raise ValueError(
+                "max_features must be an int in [1, n_features] or a float "
+                "in (0.0, 1.0]."
+            )
+        self._n_features_per_tree = actual_max_features
+
+        if isinstance(self.contamination, str):
+            if self.contamination != "auto":
+                raise ValueError(
+                    "contamination must be 'auto' or a float in the range "
+                    "(0, 0.5]."
+                )
+        elif isinstance(self.contamination, Real):
+            contamination_fraction = float(self.contamination)
+            if contamination_fraction <= 0.0 or contamination_fraction > 0.5:
+                raise ValueError(
+                    "contamination must be 'auto' or a float in the range "
+                    "(0, 0.5]."
+                )
+            use_contamination_quantile = True
+        else:
+            raise ValueError(
+                "contamination must be 'auto' or a float in the range "
+                "(0, 0.5]."
+            )
+
+        # Compute max_samples
         cdef int actual_max_samples
+        if isinstance(self.max_samples, str):
+            if self.max_samples != "auto":
+                raise ValueError(
+                    "max_samples must be 'auto', a positive int, or a float "
+                    "in (0.0, 1.0]."
+                )
+            actual_max_samples = min(256, n_rows)
+        elif isinstance(self.max_samples, builtins.bool):
+            raise ValueError(
+                "max_samples must be 'auto', a positive int, or a float "
+                "in (0.0, 1.0]."
+            )
+        elif isinstance(self.max_samples, Integral):
+            if self.max_samples <= 0:
+                raise ValueError("max_samples must be a positive integer.")
+            if self.max_samples > n_rows:
+                warnings.warn(
+                    f"max_samples ({self.max_samples}) is greater than the "
+                    f"total number of samples ({n_rows}). max_samples will "
+                    "be set to n_samples for estimation.",
+                    UserWarning,
+                )
+            actual_max_samples = min(self.max_samples, n_rows)
+        elif isinstance(self.max_samples, Real):
+            if self.max_samples <= 0.0 or self.max_samples > 1.0:
+                raise ValueError("float max_samples must be in (0.0, 1.0].")
+            actual_max_samples = int(self.max_samples * n_rows)
+            if actual_max_samples < 1:
+                raise ValueError(
+                    "max_samples resolves to 0 samples; increase max_samples "
+                    "or provide more training rows."
+                )
+        else:
+            raise ValueError(
+                "max_samples must be 'auto', a positive int, or a float "
+                "in (0.0, 1.0]."
+            )
+        self.max_samples_ = actual_max_samples
+
+        # Compute max_depth (-1 means auto in C++)
         cdef int actual_max_depth
-        cdef uint64_t seed
+        if self.max_depth is None:
+            actual_max_depth = -1  # C++ will compute ceil(log2(max_samples))
+        else:
+            actual_max_depth = self.max_depth
+
+        # Get random seed
+        cdef uint64_t seed = check_random_seed(self.random_state)
+
+        # Setup parameters
         cdef IF_params params
-        cdef handle_t* handle_
-        cdef level_enum verbose
+        params.n_estimators = self.n_estimators
+        params.max_samples = actual_max_samples
+        params.max_depth = actual_max_depth
+        params.max_features = actual_max_features
+        params.bootstrap = self.bootstrap
+        params.seed = seed
+
+        # Get handle and verbosity
+        handle = get_handle()
+        cdef handle_t* handle_ = <handle_t*><uintptr_t>handle.getHandle()
+        cdef level_enum verbose = <level_enum>self._verbose_level
+
         cdef _IsolationForestModel model
         cdef TreeliteModelHandle tl_handle = NULL
         cdef const char* tl_bytes = NULL
@@ -654,128 +755,6 @@ class IsolationForest(InteropMixin, CMajorInputTagMixin, Base):
         cdef int tl_free_status
 
         try:
-            # Convert input to a column-major device array for fit.
-            # ``reset=True`` sets ``n_features_in_``/``feature_names_in_``.
-            X_m = check_inputs(
-                self,
-                X,
-                dtype=(np.float32, np.float64),
-                order="F",
-                reset=True,
-            )
-            n_rows = X_m.shape[0]
-            n_cols = X_m.shape[1]
-            X_ptr = X_m.data.ptr
-            self._dtype = X_m.dtype
-
-            if isinstance(self.max_features, builtins.bool):
-                raise ValueError(
-                    "max_features must be an int in [1, n_features] or a float "
-                    "in (0.0, 1.0]."
-                )
-            elif isinstance(self.max_features, Integral):
-                if self.max_features < 1 or self.max_features > n_cols:
-                    raise ValueError(
-                        "max_features must be an int in [1, n_features] or a "
-                        "float in (0.0, 1.0]."
-                    )
-                actual_max_features = int(self.max_features)
-            elif isinstance(self.max_features, Real):
-                if self.max_features <= 0.0 or self.max_features > 1.0:
-                    raise ValueError(
-                        "max_features must be an int in [1, n_features] or a "
-                        "float in (0.0, 1.0]."
-                    )
-                actual_max_features = max(1, int(self.max_features * n_cols))
-            else:
-                raise ValueError(
-                    "max_features must be an int in [1, n_features] or a float "
-                    "in (0.0, 1.0]."
-                )
-            self._n_features_per_tree = actual_max_features
-
-            if isinstance(self.contamination, str):
-                if self.contamination != "auto":
-                    raise ValueError(
-                        "contamination must be 'auto' or a float in the range "
-                        "(0, 0.5]."
-                    )
-            elif isinstance(self.contamination, Real):
-                contamination_fraction = float(self.contamination)
-                if contamination_fraction <= 0.0 or contamination_fraction > 0.5:
-                    raise ValueError(
-                        "contamination must be 'auto' or a float in the range "
-                        "(0, 0.5]."
-                    )
-                use_contamination_quantile = True
-            else:
-                raise ValueError(
-                    "contamination must be 'auto' or a float in the range "
-                    "(0, 0.5]."
-                )
-
-            # Compute max_samples
-            if isinstance(self.max_samples, str):
-                if self.max_samples != "auto":
-                    raise ValueError(
-                        "max_samples must be 'auto', a positive int, or a float "
-                        "in (0.0, 1.0]."
-                    )
-                actual_max_samples = min(256, n_rows)
-            elif isinstance(self.max_samples, builtins.bool):
-                raise ValueError(
-                    "max_samples must be 'auto', a positive int, or a float "
-                    "in (0.0, 1.0]."
-                )
-            elif isinstance(self.max_samples, Integral):
-                if self.max_samples <= 0:
-                    raise ValueError("max_samples must be a positive integer.")
-                if self.max_samples > n_rows:
-                    warnings.warn(
-                        f"max_samples ({self.max_samples}) is greater than the "
-                        f"total number of samples ({n_rows}). max_samples will "
-                        "be set to n_samples for estimation.",
-                        UserWarning,
-                    )
-                actual_max_samples = min(self.max_samples, n_rows)
-            elif isinstance(self.max_samples, Real):
-                if self.max_samples <= 0.0 or self.max_samples > 1.0:
-                    raise ValueError("float max_samples must be in (0.0, 1.0].")
-                actual_max_samples = int(self.max_samples * n_rows)
-                if actual_max_samples < 1:
-                    raise ValueError(
-                        "max_samples resolves to 0 samples; increase max_samples "
-                        "or provide more training rows."
-                    )
-            else:
-                raise ValueError(
-                    "max_samples must be 'auto', a positive int, or a float "
-                    "in (0.0, 1.0]."
-                )
-            self.max_samples_ = actual_max_samples
-
-            # Compute max_depth (-1 means auto in C++)
-            if self.max_depth is None:
-                actual_max_depth = -1  # C++ will compute ceil(log2(max_samples))
-            else:
-                actual_max_depth = self.max_depth
-
-            # Get random seed
-            seed = check_random_seed(self.random_state)
-
-            # Setup parameters
-            params.n_estimators = self.n_estimators
-            params.max_samples = actual_max_samples
-            params.max_depth = actual_max_depth
-            params.max_features = actual_max_features
-            params.bootstrap = self.bootstrap
-            params.seed = seed
-
-            # Get handle and verbosity
-            handle = get_handle()
-            handle_ = <handle_t*><uintptr_t>handle.getHandle()
-            verbose = <level_enum>self._verbose_level
-
             if X_m.dtype == np.float32:
                 model = _IsolationForestModelFloat32()
             else:
@@ -806,23 +785,26 @@ class IsolationForest(InteropMixin, CMajorInputTagMixin, Base):
             safe_treelite_call(
                 tl_free_status, "Failed to free Treelite model:"
             )
-            self._treelite_model_bytes = <bytes>(tl_bytes[:tl_bytes_len])
-            self._nvforest_model = None
-
-            if use_contamination_quantile:
-                training_scores = self.score_samples(X_m)
-                self.offset_ = float(
-                    cp.percentile(
-                        training_scores, 100.0 * contamination_fraction
-                    ).get()
-                )
-            else:
-                self.offset_ = -0.5
         except Exception:
             if tl_handle != NULL:
                 TreeliteFreeModel(tl_handle)
-            self._reset_fitted_state()
+            self._model = None
+            self._treelite_model_bytes = None
+            self._nvforest_model = None
             raise
+
+        self._treelite_model_bytes = <bytes>(tl_bytes[:tl_bytes_len])
+        self._nvforest_model = None
+
+        if use_contamination_quantile:
+            training_scores = self.score_samples(X_m)
+            self.offset_ = float(
+                cp.percentile(
+                    training_scores, 100.0 * contamination_fraction
+                ).get()
+            )
+        else:
+            self.offset_ = -0.5
 
         return self
 

--- a/python/cuml/cuml/ensemble/isolation_forest.pyx
+++ b/python/cuml/cuml/ensemble/isolation_forest.pyx
@@ -29,7 +29,11 @@ from cuml.internals.interop import (
 from cuml.internals.mixins import CMajorInputTagMixin
 from cuml.internals.outputs import mlfunc
 from cuml.internals.treelite import safe_treelite_call
-from cuml.internals.validation import check_inputs, check_random_seed
+from cuml.internals.validation import (
+    check_inputs,
+    check_is_fitted,
+    check_random_seed,
+)
 
 from libc.stddef cimport size_t
 from libc.stdint cimport uint64_t, uintptr_t
@@ -570,6 +574,12 @@ class IsolationForest(InteropMixin, CMajorInputTagMixin, Base):
         self.__dict__.update(state)
 
     @mlfunc(set_input_type=True)
+    def __sklearn_check_is_fitted__(self):
+        """Fitted means the native model is present: public attributes
+        survive unpickling, but the native model does not, and inference
+        requires it."""
+        return self._model is not None
+
     def fit(self, X, y=None, sample_weight=None):
         """
         Fit the Isolation Forest model.
@@ -912,9 +922,8 @@ class IsolationForest(InteropMixin, CMajorInputTagMixin, Base):
             Typical range is approximately [-1.0, 0.0], where values below
             ``offset_`` are predicted as anomalies.
         """
+        check_is_fitted(self)
         cdef _IsolationForestModel model = self._model
-        if model is None:
-            raise NotFittedError("Model has not been fitted. Call fit() first.")
 
         # Convert input to a row-major device array for inference.
         X_m = check_inputs(
@@ -1002,9 +1011,8 @@ class IsolationForest(InteropMixin, CMajorInputTagMixin, Base):
         labels : ndarray of shape (n_samples,)
             1 for inliers, -1 for outliers.
         """
+        check_is_fitted(self)
         cdef _IsolationForestModel model = self._model
-        if model is None:
-            raise NotFittedError("Model has not been fitted. Call fit() first.")
 
         # Convert input to a row-major device array for inference.
         X_m = check_inputs(

--- a/python/cuml/cuml/ensemble/isolation_forest.pyx
+++ b/python/cuml/cuml/ensemble/isolation_forest.pyx
@@ -577,11 +577,17 @@ class IsolationForest(InteropMixin, CMajorInputTagMixin, Base):
             "Conversion of a fitted cuML IsolationForest is not supported"
         )
 
+    @staticmethod
+    def _clear_fitted_state(state):
+        """Applies the unfitted baseline to the ``state`` mapping in place."""
+        state.update(_UNFITTED_BASELINE)
+        for attr in _FITTED_ONLY_ATTRS:
+            state.pop(attr, None)
+        return state
+
     def _reset_fitted_state(self):
         """Returns the estimator to its unfitted construction state."""
-        self.__dict__.update(_UNFITTED_BASELINE)
-        for attr in _FITTED_ONLY_ATTRS:
-            self.__dict__.pop(attr, None)
+        self._clear_fitted_state(self.__dict__)
 
     def __getstate__(self):
         """Pickle support: the native model cannot be serialized, so the
@@ -594,10 +600,7 @@ class IsolationForest(InteropMixin, CMajorInputTagMixin, Base):
                 "state. The unpickled estimator is unfitted; call fit() "
                 "again before using it."
             )
-        state.update(_UNFITTED_BASELINE)
-        for attr in _FITTED_ONLY_ATTRS:
-            state.pop(attr, None)
-        return state
+        return self._clear_fitted_state(state)
 
     def __setstate__(self, state):
         """Pickle support - restore state."""

--- a/python/cuml/cuml/ensemble/isolation_forest.pyx
+++ b/python/cuml/cuml/ensemble/isolation_forest.pyx
@@ -573,13 +573,13 @@ class IsolationForest(InteropMixin, CMajorInputTagMixin, Base):
         """Pickle support - restore state."""
         self.__dict__.update(state)
 
-    @mlfunc(set_input_type=True)
-    def __sklearn_check_is_fitted__(self):
+    def __sklearn_is_fitted__(self):
         """Fitted means the native model is present: public attributes
         survive unpickling, but the native model does not, and inference
         requires it."""
         return self._model is not None
 
+    @mlfunc(set_input_type=True)
     def fit(self, X, y=None, sample_weight=None):
         """
         Fit the Isolation Forest model.

--- a/python/cuml/cuml/ensemble/isolation_forest.pyx
+++ b/python/cuml/cuml/ensemble/isolation_forest.pyx
@@ -18,7 +18,6 @@ import cupy as cp
 import numpy as np
 import nvforest
 import treelite
-from sklearn.exceptions import NotFittedError
 
 from cuml.internals.base import Base, get_handle
 from cuml.internals.interop import (
@@ -357,6 +356,27 @@ cdef class _IsolationForestModelFloat64(_IsolationForestModel):
             )
 
 
+# Baseline values (matching ``__init__``) restored whenever the fitted state
+# is dropped.
+_UNFITTED_BASELINE = {
+    "_model": None,
+    "_dtype": None,
+    "_treelite_model_bytes": None,
+    "_nvforest_model": None,
+    "_c_normalization": None,
+    "_n_features_per_tree": None,
+}
+
+# Attributes that only exist on a fitted estimator.
+_FITTED_ONLY_ATTRS = (
+    "n_features_in_",
+    "feature_names_in_",
+    "max_samples_",
+    "offset_",
+    "_n_samples_per_tree",
+)
+
+
 class IsolationForest(InteropMixin, CMajorInputTagMixin, Base):
     """
     GPU-accelerated Isolation Forest for anomaly detection.
@@ -557,27 +577,31 @@ class IsolationForest(InteropMixin, CMajorInputTagMixin, Base):
             "Conversion of a fitted cuML IsolationForest is not supported"
         )
 
+    def _reset_fitted_state(self):
+        """Returns the estimator to its unfitted construction state."""
+        self.__dict__.update(_UNFITTED_BASELINE)
+        for attr in _FITTED_ONLY_ATTRS:
+            self.__dict__.pop(attr, None)
+
     def __getstate__(self):
-        """Pickle support - serialize state."""
+        """Pickle support: the native model cannot be serialized, so the
+        fitted state is dropped entirely and the unpickled estimator is
+        unfitted, keeping only its constructor parameters."""
         state = self.__dict__.copy()
-        # The native model is not currently serialized.
-        state["_model"] = None
-        state.pop("_nvforest_model", None)
-        warnings.warn(
-            "IsolationForest model serialization is not fully supported. "
-            "The model will need to be re-fitted after unpickling."
-        )
+        if self._model is not None:
+            warnings.warn(
+                "cuML IsolationForest does not serialize its fitted "
+                "state. The unpickled estimator is unfitted; call fit() "
+                "again before using it."
+            )
+        state.update(_UNFITTED_BASELINE)
+        for attr in _FITTED_ONLY_ATTRS:
+            state.pop(attr, None)
         return state
 
     def __setstate__(self, state):
         """Pickle support - restore state."""
         self.__dict__.update(state)
-
-    def __sklearn_is_fitted__(self):
-        """Fitted means the native model is present: public attributes
-        survive unpickling, but the native model does not, and inference
-        requires it."""
-        return self._model is not None
 
     @mlfunc(set_input_type=True)
     def fit(self, X, y=None, sample_weight=None):
@@ -604,138 +628,22 @@ class IsolationForest(InteropMixin, CMajorInputTagMixin, Base):
         if sample_weight is not None:
             raise UnsupportedOnGPU("`sample_weight` is not supported")
 
-        # Release any existing native model.
-        self._model = None
+        # Drop any previous fitted state up front, so that a failed fit
+        # leaves the estimator unfitted rather than half fitted.
+        self._reset_fitted_state()
 
-        # Convert input to a column-major device array for fit.
-        X_m = check_inputs(
-            self,
-            X,
-            dtype=(np.float32, np.float64),
-            order="F",
-            reset=True,
-        )
-
-        cdef size_t n_rows = X_m.shape[0]
-        cdef int n_cols = X_m.shape[1]
-        cdef uintptr_t X_ptr = X_m.data.ptr
+        cdef size_t n_rows
+        cdef int n_cols
+        cdef uintptr_t X_ptr
         cdef double contamination_fraction = 0.0
         cdef bint use_contamination_quantile = False
-        self.n_features_in_ = n_cols
-        self._dtype = X_m.dtype
-
         cdef int actual_max_features
-        if isinstance(self.max_features, builtins.bool):
-            raise ValueError(
-                "max_features must be an int in [1, n_features] or a float "
-                "in (0.0, 1.0]."
-            )
-        elif isinstance(self.max_features, Integral):
-            if self.max_features < 1 or self.max_features > n_cols:
-                raise ValueError(
-                    "max_features must be an int in [1, n_features] or a "
-                    "float in (0.0, 1.0]."
-                )
-            actual_max_features = int(self.max_features)
-        elif isinstance(self.max_features, Real):
-            if self.max_features <= 0.0 or self.max_features > 1.0:
-                raise ValueError(
-                    "max_features must be an int in [1, n_features] or a "
-                    "float in (0.0, 1.0]."
-                )
-            actual_max_features = max(1, int(self.max_features * n_cols))
-        else:
-            raise ValueError(
-                "max_features must be an int in [1, n_features] or a float "
-                "in (0.0, 1.0]."
-            )
-        self._n_features_per_tree = actual_max_features
-
-        if isinstance(self.contamination, str):
-            if self.contamination != "auto":
-                raise ValueError(
-                    "contamination must be 'auto' or a float in the range "
-                    "(0, 0.5]."
-                )
-        elif isinstance(self.contamination, Real):
-            contamination_fraction = float(self.contamination)
-            if contamination_fraction <= 0.0 or contamination_fraction > 0.5:
-                raise ValueError(
-                    "contamination must be 'auto' or a float in the range "
-                    "(0, 0.5]."
-                )
-            use_contamination_quantile = True
-        else:
-            raise ValueError(
-                "contamination must be 'auto' or a float in the range "
-                "(0, 0.5]."
-            )
-
-        # Compute max_samples
         cdef int actual_max_samples
-        if isinstance(self.max_samples, str):
-            if self.max_samples != "auto":
-                raise ValueError(
-                    "max_samples must be 'auto', a positive int, or a float "
-                    "in (0.0, 1.0]."
-                )
-            actual_max_samples = min(256, n_rows)
-        elif isinstance(self.max_samples, builtins.bool):
-            raise ValueError(
-                "max_samples must be 'auto', a positive int, or a float "
-                "in (0.0, 1.0]."
-            )
-        elif isinstance(self.max_samples, Integral):
-            if self.max_samples <= 0:
-                raise ValueError("max_samples must be a positive integer.")
-            if self.max_samples > n_rows:
-                warnings.warn(
-                    f"max_samples ({self.max_samples}) is greater than the "
-                    f"total number of samples ({n_rows}). max_samples will "
-                    "be set to n_samples for estimation.",
-                    UserWarning,
-                )
-            actual_max_samples = min(self.max_samples, n_rows)
-        elif isinstance(self.max_samples, Real):
-            if self.max_samples <= 0.0 or self.max_samples > 1.0:
-                raise ValueError("float max_samples must be in (0.0, 1.0].")
-            actual_max_samples = int(self.max_samples * n_rows)
-            if actual_max_samples < 1:
-                raise ValueError(
-                    "max_samples resolves to 0 samples; increase max_samples "
-                    "or provide more training rows."
-                )
-        else:
-            raise ValueError(
-                "max_samples must be 'auto', a positive int, or a float "
-                "in (0.0, 1.0]."
-            )
-        self.max_samples_ = actual_max_samples
-
-        # Compute max_depth (-1 means auto in C++)
         cdef int actual_max_depth
-        if self.max_depth is None:
-            actual_max_depth = -1  # C++ will compute ceil(log2(max_samples))
-        else:
-            actual_max_depth = self.max_depth
-
-        # Get random seed
-        cdef uint64_t seed = check_random_seed(self.random_state)
-
-        # Setup parameters
+        cdef uint64_t seed
         cdef IF_params params
-        params.n_estimators = self.n_estimators
-        params.max_samples = actual_max_samples
-        params.max_depth = actual_max_depth
-        params.max_features = actual_max_features
-        params.bootstrap = self.bootstrap
-        params.seed = seed
-
-        # Get handle and verbosity
-        handle = get_handle()
-        cdef handle_t* handle_ = <handle_t*><uintptr_t>handle.getHandle()
-        cdef level_enum verbose = <level_enum>self._verbose_level
-
+        cdef handle_t* handle_
+        cdef level_enum verbose
         cdef _IsolationForestModel model
         cdef TreeliteModelHandle tl_handle = NULL
         cdef const char* tl_bytes = NULL
@@ -743,6 +651,128 @@ class IsolationForest(InteropMixin, CMajorInputTagMixin, Base):
         cdef int tl_free_status
 
         try:
+            # Convert input to a column-major device array for fit.
+            # ``reset=True`` sets ``n_features_in_``/``feature_names_in_``.
+            X_m = check_inputs(
+                self,
+                X,
+                dtype=(np.float32, np.float64),
+                order="F",
+                reset=True,
+            )
+            n_rows = X_m.shape[0]
+            n_cols = X_m.shape[1]
+            X_ptr = X_m.data.ptr
+            self._dtype = X_m.dtype
+
+            if isinstance(self.max_features, builtins.bool):
+                raise ValueError(
+                    "max_features must be an int in [1, n_features] or a float "
+                    "in (0.0, 1.0]."
+                )
+            elif isinstance(self.max_features, Integral):
+                if self.max_features < 1 or self.max_features > n_cols:
+                    raise ValueError(
+                        "max_features must be an int in [1, n_features] or a "
+                        "float in (0.0, 1.0]."
+                    )
+                actual_max_features = int(self.max_features)
+            elif isinstance(self.max_features, Real):
+                if self.max_features <= 0.0 or self.max_features > 1.0:
+                    raise ValueError(
+                        "max_features must be an int in [1, n_features] or a "
+                        "float in (0.0, 1.0]."
+                    )
+                actual_max_features = max(1, int(self.max_features * n_cols))
+            else:
+                raise ValueError(
+                    "max_features must be an int in [1, n_features] or a float "
+                    "in (0.0, 1.0]."
+                )
+            self._n_features_per_tree = actual_max_features
+
+            if isinstance(self.contamination, str):
+                if self.contamination != "auto":
+                    raise ValueError(
+                        "contamination must be 'auto' or a float in the range "
+                        "(0, 0.5]."
+                    )
+            elif isinstance(self.contamination, Real):
+                contamination_fraction = float(self.contamination)
+                if contamination_fraction <= 0.0 or contamination_fraction > 0.5:
+                    raise ValueError(
+                        "contamination must be 'auto' or a float in the range "
+                        "(0, 0.5]."
+                    )
+                use_contamination_quantile = True
+            else:
+                raise ValueError(
+                    "contamination must be 'auto' or a float in the range "
+                    "(0, 0.5]."
+                )
+
+            # Compute max_samples
+            if isinstance(self.max_samples, str):
+                if self.max_samples != "auto":
+                    raise ValueError(
+                        "max_samples must be 'auto', a positive int, or a float "
+                        "in (0.0, 1.0]."
+                    )
+                actual_max_samples = min(256, n_rows)
+            elif isinstance(self.max_samples, builtins.bool):
+                raise ValueError(
+                    "max_samples must be 'auto', a positive int, or a float "
+                    "in (0.0, 1.0]."
+                )
+            elif isinstance(self.max_samples, Integral):
+                if self.max_samples <= 0:
+                    raise ValueError("max_samples must be a positive integer.")
+                if self.max_samples > n_rows:
+                    warnings.warn(
+                        f"max_samples ({self.max_samples}) is greater than the "
+                        f"total number of samples ({n_rows}). max_samples will "
+                        "be set to n_samples for estimation.",
+                        UserWarning,
+                    )
+                actual_max_samples = min(self.max_samples, n_rows)
+            elif isinstance(self.max_samples, Real):
+                if self.max_samples <= 0.0 or self.max_samples > 1.0:
+                    raise ValueError("float max_samples must be in (0.0, 1.0].")
+                actual_max_samples = int(self.max_samples * n_rows)
+                if actual_max_samples < 1:
+                    raise ValueError(
+                        "max_samples resolves to 0 samples; increase max_samples "
+                        "or provide more training rows."
+                    )
+            else:
+                raise ValueError(
+                    "max_samples must be 'auto', a positive int, or a float "
+                    "in (0.0, 1.0]."
+                )
+            self.max_samples_ = actual_max_samples
+
+            # Compute max_depth (-1 means auto in C++)
+            if self.max_depth is None:
+                actual_max_depth = -1  # C++ will compute ceil(log2(max_samples))
+            else:
+                actual_max_depth = self.max_depth
+
+            # Get random seed
+            seed = check_random_seed(self.random_state)
+
+            # Setup parameters
+            params.n_estimators = self.n_estimators
+            params.max_samples = actual_max_samples
+            params.max_depth = actual_max_depth
+            params.max_features = actual_max_features
+            params.bootstrap = self.bootstrap
+            params.seed = seed
+
+            # Get handle and verbosity
+            handle = get_handle()
+            handle_ = <handle_t*><uintptr_t>handle.getHandle()
+            verbose = <level_enum>self._verbose_level
+
             if X_m.dtype == np.float32:
                 model = _IsolationForestModelFloat32()
             else:
@@ -773,26 +803,23 @@ class IsolationForest(InteropMixin, CMajorInputTagMixin, Base):
             safe_treelite_call(
                 tl_free_status, "Failed to free Treelite model:"
             )
+            self._treelite_model_bytes = <bytes>(tl_bytes[:tl_bytes_len])
+            self._nvforest_model = None
+
+            if use_contamination_quantile:
+                training_scores = self.score_samples(X_m)
+                self.offset_ = float(
+                    cp.percentile(
+                        training_scores, 100.0 * contamination_fraction
+                    ).get()
+                )
+            else:
+                self.offset_ = -0.5
         except Exception:
             if tl_handle != NULL:
                 TreeliteFreeModel(tl_handle)
-            self._model = None
-            self._treelite_model_bytes = None
-            self._nvforest_model = None
+            self._reset_fitted_state()
             raise
-
-        self._treelite_model_bytes = <bytes>(tl_bytes[:tl_bytes_len])
-        self._nvforest_model = None
-
-        if use_contamination_quantile:
-            training_scores = self.score_samples(X_m)
-            self.offset_ = float(
-                cp.percentile(
-                    training_scores, 100.0 * contamination_fraction
-                ).get()
-            )
-        else:
-            self.offset_ = -0.5
 
         return self
 
@@ -807,8 +834,7 @@ class IsolationForest(InteropMixin, CMajorInputTagMixin, Base):
         -------
         treelite.Model
         """
-        if self._treelite_model_bytes is None:
-            raise NotFittedError("Model has not been fitted. Call fit() first.")
+        check_is_fitted(self)
 
         return treelite.Model.deserialize_bytes(self._treelite_model_bytes)
 
@@ -823,8 +849,7 @@ class IsolationForest(InteropMixin, CMajorInputTagMixin, Base):
         nvforest_model : nvforest.ForestInference
             A forest inference model that predicts average path length.
         """
-        if self._treelite_model_bytes is None:
-            raise NotFittedError("Model has not been fitted. Call fit() first.")
+        check_is_fitted(self)
 
         return nvforest.load_from_treelite_model(
             tl_model=treelite.Model.deserialize_bytes(self._treelite_model_bytes),
@@ -869,8 +894,7 @@ class IsolationForest(InteropMixin, CMajorInputTagMixin, Base):
         are added. Public ``score_samples`` continues to use the existing C++
         scoring path.
         """
-        if self._treelite_model_bytes is None:
-            raise NotFittedError("Model has not been fitted. Call fit() first.")
+        check_is_fitted(self)
 
         X_m = check_inputs(
             self,

--- a/python/cuml/tests/test_isolation_forest.py
+++ b/python/cuml/tests/test_isolation_forest.py
@@ -735,24 +735,6 @@ def test_many_features():
     assert scores.shape == (X.shape[0],)
 
 
-def test_predict_before_fit_raises():
-    """predict() before fit() should raise an error."""
-    clf = cuIsolationForest()
-    X = np.random.randn(10, 3).astype(np.float32)
-
-    with pytest.raises(NotFittedError, match="not been fitted"):
-        clf.predict(X)
-
-
-def test_score_samples_before_fit_raises():
-    """score_samples() before fit() should raise an error."""
-    clf = cuIsolationForest()
-    X = np.random.randn(10, 3).astype(np.float32)
-
-    with pytest.raises(NotFittedError, match="not been fitted"):
-        clf.score_samples(X)
-
-
 def test_feature_mismatch_raises(blobs_data):
     """Predicting with wrong number of features should raise."""
     clf = cuIsolationForest(n_estimators=10, random_state=42)

--- a/python/cuml/tests/test_isolation_forest.py
+++ b/python/cuml/tests/test_isolation_forest.py
@@ -18,6 +18,7 @@ import pytest
 import treelite
 from sklearn.datasets import make_blobs
 from sklearn.ensemble import IsolationForest as skIsolationForest
+from sklearn.exceptions import NotFittedError
 
 from cuml import IsolationForest as cuIsolationForest
 from cuml.internals.interop import UnsupportedOnCPU, UnsupportedOnGPU
@@ -615,13 +616,13 @@ def test_treelite_export_before_fit_raises(blobs_data):
     """Treelite and nvForest export should require a fitted model."""
     clf = cuIsolationForest()
 
-    with pytest.raises(RuntimeError, match="not been fitted"):
+    with pytest.raises(NotFittedError, match="not been fitted"):
         clf.as_treelite()
 
-    with pytest.raises(RuntimeError, match="not been fitted"):
+    with pytest.raises(NotFittedError, match="not been fitted"):
         clf.as_nvforest()
 
-    with pytest.raises(RuntimeError, match="not been fitted"):
+    with pytest.raises(NotFittedError, match="not been fitted"):
         clf._score_samples_nvforest(blobs_data)
 
 
@@ -739,7 +740,7 @@ def test_predict_before_fit_raises():
     clf = cuIsolationForest()
     X = np.random.randn(10, 3).astype(np.float32)
 
-    with pytest.raises(RuntimeError, match="not been fitted"):
+    with pytest.raises(NotFittedError, match="not been fitted"):
         clf.predict(X)
 
 
@@ -748,7 +749,7 @@ def test_score_samples_before_fit_raises():
     clf = cuIsolationForest()
     X = np.random.randn(10, 3).astype(np.float32)
 
-    with pytest.raises(RuntimeError, match="not been fitted"):
+    with pytest.raises(NotFittedError, match="not been fitted"):
         clf.score_samples(X)
 
 

--- a/python/cuml/tests/test_isolation_forest.py
+++ b/python/cuml/tests/test_isolation_forest.py
@@ -677,20 +677,6 @@ def test_pickle_unfitted_model_is_silent():
     assert loaded.get_params() == clf.get_params()
 
 
-def test_failed_fit_leaves_estimator_unfitted(blobs_data):
-    """A failed fit must leave the estimator genuinely unfitted rather than
-    half fitted."""
-    clf = cuIsolationForest(n_estimators=10, random_state=42).fit(blobs_data)
-    clf.max_features = 0
-
-    with pytest.raises(ValueError, match="max_features"):
-        clf.fit(blobs_data)
-
-    assert _fitted_only_attrs(clf) == []
-    with pytest.raises(NotFittedError, match="not fitted"):
-        clf.predict(blobs_data)
-
-
 # =============================================================================
 # Determinism tests
 # =============================================================================

--- a/python/cuml/tests/test_isolation_forest.py
+++ b/python/cuml/tests/test_isolation_forest.py
@@ -12,6 +12,9 @@ These tests are designed to be:
 4. Validating sklearn compatibility
 """
 
+import pickle
+import warnings
+
 import cupy as cp
 import numpy as np
 import pytest
@@ -616,14 +619,76 @@ def test_treelite_export_before_fit_raises(blobs_data):
     """Treelite and nvForest export should require a fitted model."""
     clf = cuIsolationForest()
 
-    with pytest.raises(NotFittedError, match="not been fitted"):
+    with pytest.raises(NotFittedError, match="not fitted"):
         clf.as_treelite()
 
-    with pytest.raises(NotFittedError, match="not been fitted"):
+    with pytest.raises(NotFittedError, match="not fitted"):
         clf.as_nvforest()
 
-    with pytest.raises(NotFittedError, match="not been fitted"):
+    with pytest.raises(NotFittedError, match="not fitted"):
         clf._score_samples_nvforest(blobs_data)
+
+
+# =============================================================================
+# Pickling tests
+# =============================================================================
+
+
+def _fitted_only_attrs(estimator):
+    return sorted(
+        attr
+        for attr in vars(estimator)
+        if attr.endswith("_") and not attr.startswith("__")
+    )
+
+
+def test_pickle_fitted_model_is_unfitted_after_roundtrip(blobs_data):
+    """The native model cannot be serialized: pickling a fitted model warns
+    and unpickles as a genuinely unfitted estimator with the same
+    parameters."""
+    clf = cuIsolationForest(n_estimators=10, random_state=42).fit(blobs_data)
+
+    with pytest.warns(UserWarning, match="unfitted"):
+        payload = pickle.dumps(clf)
+    loaded = pickle.loads(payload)
+
+    assert _fitted_only_attrs(loaded) == []
+    assert loaded._treelite_model_bytes is None
+    assert loaded.get_params() == clf.get_params()
+    with pytest.raises(NotFittedError, match="not fitted"):
+        loaded.predict(blobs_data)
+    with pytest.raises(NotFittedError, match="not fitted"):
+        loaded.as_treelite()
+
+    # Refitting the unpickled estimator reproduces the original model.
+    refit_scores = np.asarray(loaded.fit(blobs_data).score_samples(blobs_data))
+    original_scores = np.asarray(clf.score_samples(blobs_data))
+    np.testing.assert_allclose(refit_scores, original_scores)
+
+
+def test_pickle_unfitted_model_is_silent():
+    """Pickling an unfitted estimator round trips without warning."""
+    clf = cuIsolationForest(n_estimators=7, random_state=3)
+
+    with warnings.catch_warnings():
+        warnings.simplefilter("error")
+        loaded = pickle.loads(pickle.dumps(clf))
+
+    assert loaded.get_params() == clf.get_params()
+
+
+def test_failed_fit_leaves_estimator_unfitted(blobs_data):
+    """A failed fit must leave the estimator genuinely unfitted rather than
+    half fitted."""
+    clf = cuIsolationForest(n_estimators=10, random_state=42).fit(blobs_data)
+    clf.max_features = 0
+
+    with pytest.raises(ValueError, match="max_features"):
+        clf.fit(blobs_data)
+
+    assert _fitted_only_attrs(clf) == []
+    with pytest.raises(NotFittedError, match="not fitted"):
+        clf.predict(blobs_data)
 
 
 # =============================================================================

--- a/python/cuml/tests/test_sklearn_compatibility.py
+++ b/python/cuml/tests/test_sklearn_compatibility.py
@@ -187,9 +187,6 @@ EXCLUDED = {
 
 XFAILS = {
     IsolationForest: {
-        "check_estimators_unfitted": (
-            "Unfitted methods raise RuntimeError instead of NotFittedError"
-        ),
         "check_sample_weights_pandas_series": "Sample weights are not supported",
         "check_sample_weights_not_an_array": "Sample weights are not supported",
         "check_sample_weights_list": "Sample weights are not supported",


### PR DESCRIPTION
Contributes to #8420 (Python interoperability and persistence: "Raise `NotFittedError` from unfitted estimator methods and remove the corresponding common-estimator-check xfail").

## Description

Unfitted `IsolationForest` methods raised `RuntimeError`; scikit-learn's estimator contract (and its `check_estimators_unfitted` common check) expects `sklearn.exceptions.NotFittedError`. This change:

- converts the five unfitted-model raises in `isolation_forest.pyx` (`predict`, `score_samples`, `as_treelite`, `as_nvforest`, `_score_samples_nvforest`) from `RuntimeError` to `NotFittedError`, keeping the message unchanged;
- removes the `check_estimators_unfitted` xfail from `test_sklearn_compatibility.py`;
- updates the five corresponding assertions in `test_isolation_forest.py`.

`NotFittedError` subclasses `ValueError` and `AttributeError`, so any caller currently catching those broad types keeps working; only code catching `RuntimeError` specifically would notice, and the estimator is new in 26.08.

## Verification

- Against the current `cuml-cu13==26.08.00a171` nightly wheel (GTX 1650 Ti, WSL2), the three updated unfitted tests fail as expected with the old `RuntimeError`, and the remaining 82 tests in `test_isolation_forest.py` pass, so the assertions encode exactly the target behavior and nothing else in the suite is affected.
- `ruff check` / `ruff format --check` on the two test files and `cython-lint` on the `.pyx` are clean (remaining ruff findings are pre-existing on `main`, only shifted line numbers).
- I do not have a local CUDA toolchain to compile the modified `.pyx`; the change is a five-site exception-type swap plus one import, and CI's estimator-check job exercises `check_estimators_unfitted` directly.
