### PR TITLE
Align documentation with NVIDIA cuML branding

### DIFF
--- a/docs/source/advanced.rst
+++ b/docs/source/advanced.rst
@@ -90,5 +90,5 @@ For more details, see the `RMM documentation`_.
 .. _per-thread default stream: https://docs.nvidia.com/cuda/cuda-programming-guide/02-basics/asynchronous-execution.html#per-thread-default-stream
 .. _legacy default stream: https://docs.nvidia.com/cuda/cuda-programming-guide/02-basics/asynchronous-execution.html#legacy-default-stream
 .. _Rapids Memory Manager:
-.. _RMM documentation: https://docs.rapids.ai/api/rmm/stable/
+.. _RMM documentation: https://docs.nvidia.com/rmm/latest/
 .. _CUDA Unified Memory: https://docs.nvidia.com/cuda/cuda-programming-guide/04-special-topics/unified-memory.html

--- a/docs/source/advanced.rst
+++ b/docs/source/advanced.rst
@@ -90,5 +90,7 @@ For more details, see the `RMM documentation`_.
 .. _per-thread default stream: https://docs.nvidia.com/cuda/cuda-programming-guide/02-basics/asynchronous-execution.html#per-thread-default-stream
 .. _legacy default stream: https://docs.nvidia.com/cuda/cuda-programming-guide/02-basics/asynchronous-execution.html#legacy-default-stream
 .. _Rapids Memory Manager:
-.. _RMM documentation: https://docs.nvidia.com/rmm/latest/
+.. Keep this version-pinned until stable subpath redirects are available:
+   https://github.com/rapidsai/build-infra/issues/395
+.. _RMM documentation: https://docs.nvidia.com/rmm/26.10/
 .. _CUDA Unified Memory: https://docs.nvidia.com/cuda/cuda-programming-guide/04-special-topics/unified-memory.html

--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -209,7 +209,7 @@ texinfo_documents = [
 
 # Example configuration for intersphinx: refer to the Python standard library.
 intersphinx_mapping = {
-    "cudf": ("https://docs.rapids.ai/api/cudf/stable/", None),
+    "cudf": ("https://docs.nvidia.com/cudf/latest/", None),
     "numpy": ("https://numpy.org/doc/stable/", None),
     "python": ("https://docs.python.org/3", None),
     # TODO: re-enable once scipy docs are more reliable
@@ -220,7 +220,7 @@ intersphinx_mapping = {
         "https://nvidia.github.io/cuda-python/cuda-core/latest/",
         None,
     ),
-    "rmm": ("https://docs.rapids.ai/api/rmm/stable/", None),
+    "rmm": ("https://docs.nvidia.com/rmm/latest/", None),
 }
 
 # Config numpydoc

--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -209,7 +209,10 @@ texinfo_documents = [
 
 # Example configuration for intersphinx: refer to the Python standard library.
 intersphinx_mapping = {
-    "cudf": ("https://docs.nvidia.com/cudf/latest/", None),
+    # TODO: Use stable URLs once subpath redirects are available:
+    # https://github.com/rapidsai/build-infra/issues/395
+    # rapids-pre-commit-hooks: disable-next-line
+    "cudf": ("https://docs.nvidia.com/cudf/26.10/", None),
     "numpy": ("https://numpy.org/doc/stable/", None),
     "python": ("https://docs.python.org/3", None),
     # TODO: re-enable once scipy docs are more reliable
@@ -220,7 +223,8 @@ intersphinx_mapping = {
         "https://nvidia.github.io/cuda-python/cuda-core/latest/",
         None,
     ),
-    "rmm": ("https://docs.nvidia.com/rmm/latest/", None),
+    # rapids-pre-commit-hooks: disable-next-line
+    "rmm": ("https://docs.nvidia.com/rmm/26.10/", None),
 }
 
 # Config numpydoc

--- a/docs/source/cuml-accel/examples/index.rst
+++ b/docs/source/cuml-accel/examples/index.rst
@@ -3,7 +3,7 @@ Examples
 
 Here we provide a few examples of using ``cuml.accel``. The code for the
 examples in this section is available in the cuML GitHub repository at `examples
-<https://github.com/NVIDIA/cuml/tree/HEAD/docs/source/cuml-accel/examples>`_.
+<https://github.com/NVIDIA/cuml/tree/main/docs/source/cuml-accel/examples>`_.
 
 .. toctree::
    :maxdepth: 1

--- a/docs/source/cuml_intro.rst
+++ b/docs/source/cuml_intro.rst
@@ -108,9 +108,8 @@ Performance gains vary by algorithm and dataset size:
    enough data to keep the GPU busy. Expect larger performance gains as dataset
    size grows.
 
-The `cuml.benchmark
-<https://docs.rapids.ai/api/cuml/nightly/api.html#benchmarking>`_ module
-provides an easy interface to benchmark your own hardware.
+The :doc:`cuml.benchmark <api/cuml.benchmark>` module provides an easy interface
+to benchmark your own hardware.
 
 
 What's Next

--- a/docs/source/cuml_intro.rst
+++ b/docs/source/cuml_intro.rst
@@ -120,7 +120,7 @@ Here are some suggestions on what to explore next:
 1. **Try the examples**: Walk through the `Introductory Notebook
    <estimator_intro.ipynb>`_ for hands-on learning
 2. **Explore the API**: Browse the `API Reference <api>`_ for specific algorithms
-3. **Check out notebooks**: Try examples in the `notebooks <https://github.com/NVIDIA/cuml/tree/HEAD/notebooks>`_ directory
+3. **Check out notebooks**: Try examples in the `notebooks <https://github.com/NVIDIA/cuml/tree/main/notebooks>`_ directory
 4. **Learn advanced topics**: Read the `cuML blogs <cuml_blogs.rst>`_ for deeper insights
 5. **Get help**: Visit our `GitHub Issues <https://github.com/NVIDIA/cuml/issues>`_
    or `RAPIDS Community <https://rapids.ai/community.html>`_

--- a/docs/source/cuml_intro.rst
+++ b/docs/source/cuml_intro.rst
@@ -123,4 +123,4 @@ Here are some suggestions on what to explore next:
 3. **Check out notebooks**: Try examples in the `notebooks <https://github.com/NVIDIA/cuml/tree/main/notebooks>`_ directory
 4. **Learn advanced topics**: Read the `cuML blogs <cuml_blogs.rst>`_ for deeper insights
 5. **Get help**: Visit our `GitHub Issues <https://github.com/NVIDIA/cuml/issues>`_
-   or `RAPIDS Community <https://rapids.ai/community.html>`_
+   or join the `CUDA-X Data Science Community <https://developer.nvidia.com/topics/ai/data-science/cuda-x-for-data-science#join-the-community>`_

--- a/docs/source/dask_multigpu_guide.ipynb
+++ b/docs/source/dask_multigpu_guide.ipynb
@@ -372,7 +372,7 @@
     "\n",
     "cuML provides Dask implementations for many popular algorithms including clustering (KMeans, DBSCAN), ensemble methods (Random Forest), linear models (LinearRegression, Logistic Regression, Ridge, Lasso), decomposition (PCA, TruncatedSVD), nearest neighbors, and more. All are available in the `cuml.dask` module.\n",
     "\n",
-    "For a comprehensive list of supported algorithms and their documentation, see the [Multi-Node, Multi-GPU Algorithms](api/#multi-node-multi-gpu-algorithms) section of the API reference."
+    "For a comprehensive list of supported algorithms and their documentation, see the [Multi-Node, Multi-GPU Algorithms](api/index.rst#multi-node-multi-gpu-algorithms) section of the API reference."
    ]
   },
   {
@@ -480,7 +480,7 @@
    "source": [
     "## Additional Resources\n",
     "\n",
-    "- **API Reference**: [Multi-Node, Multi-GPU Algorithms](api/#multi-node-multi-gpu-algorithms)\n",
+    "- **API Reference**: [Multi-Node, Multi-GPU Algorithms](api/index.rst#multi-node-multi-gpu-algorithms)\n",
     "- **Cluster Setup**: [RAPIDS dask-cuda Examples (UCX, multi-node configuration)](https://docs.rapids.ai/api/dask-cuda/stable/examples/ucx/)\n",
     "- **Dask Documentation**: [Dask Distributed](https://distributed.dask.org/)\n",
     "- **Dask-CUDA**: [Dask-CUDA Documentation](https://docs.rapids.ai/api/dask-cuda/stable/)\n"

--- a/docs/source/dask_multigpu_guide.ipynb
+++ b/docs/source/dask_multigpu_guide.ipynb
@@ -372,7 +372,7 @@
     "\n",
     "cuML provides Dask implementations for many popular algorithms including clustering (KMeans, DBSCAN), ensemble methods (Random Forest), linear models (LinearRegression, Logistic Regression, Ridge, Lasso), decomposition (PCA, TruncatedSVD), nearest neighbors, and more. All are available in the `cuml.dask` module.\n",
     "\n",
-    "For a comprehensive list of supported algorithms and their documentation, see the [Multi-Node, Multi-GPU Algorithms](https://docs.rapids.ai/api/cuml/stable/api.html#multi-node-multi-gpu-algorithms) section of the API reference."
+    "For a comprehensive list of supported algorithms and their documentation, see the [Multi-Node, Multi-GPU Algorithms](api/#multi-node-multi-gpu-algorithms) section of the API reference."
    ]
   },
   {
@@ -480,7 +480,7 @@
    "source": [
     "## Additional Resources\n",
     "\n",
-    "- **API Reference**: [Multi-Node, Multi-GPU Algorithms](https://docs.rapids.ai/api/cuml/stable/api.html#multi-node-multi-gpu-algorithms)\n",
+    "- **API Reference**: [Multi-Node, Multi-GPU Algorithms](api/#multi-node-multi-gpu-algorithms)\n",
     "- **Cluster Setup**: [RAPIDS dask-cuda Examples (UCX, multi-node configuration)](https://docs.rapids.ai/api/dask-cuda/stable/examples/ucx/)\n",
     "- **Dask Documentation**: [Dask Distributed](https://distributed.dask.org/)\n",
     "- **Dask-CUDA**: [Dask-CUDA Documentation](https://docs.rapids.ai/api/dask-cuda/stable/)\n"

--- a/docs/source/estimator_intro.ipynb
+++ b/docs/source/estimator_intro.ipynb
@@ -33,12 +33,12 @@
     "### Random Forest Classification and Accuracy metrics\n",
     "\n",
     "The Random Forest classification model builds several decision trees, and aggregates each of their outputs to make a prediction. For more information on cuML's implementation of the Random Forest Classification model please refer to:\n",
-    "[Random Forest Classifier API reference](api/generated/cuml.ensemble.RandomForestClassifier.html)\n",
+    "[Random Forest Classifier API reference](api/generated/cuml.ensemble.RandomForestClassifier.rst)\n",
     "\n",
     "Accuracy score is the ratio of correct predictions to the total number of predictions. It is used to measure the performance of classification models.\n",
     "For more information on the accuracy score metric please refer to: https://en.wikipedia.org/wiki/Accuracy_and_precision\n",
     "\n",
-    "For more information on cuML's implementation of accuracy score metrics, see the [accuracy score API reference](api/generated/cuml.metrics.accuracy_score.html).\n",
+    "For more information on cuML's implementation of accuracy score metrics, see the [accuracy score API reference](api/generated/cuml.metrics.accuracy_score.rst).\n",
     "\n",
     "The cell below shows an end-to-end pipeline of the Random Forest Classification model. Here the dataset was generated using cuML's make_classification dataset. The generated dataset was used to train and run predict on the model, and the performance is evaluated using cuML's accuracy metric."
    ]
@@ -91,11 +91,11 @@
    "source": [
     "### UMAP and Trustworthiness metrics\n",
     "UMAP is a dimensionality reduction algorithm which performs non-linear dimension reduction. It can also be used for visualization.\n",
-    "For additional information on the UMAP model, see the [UMAP API reference](api/generated/cuml.manifold.UMAP.html).\n",
+    "For additional information on the UMAP model, see the [UMAP API reference](api/generated/cuml.manifold.UMAP.rst).\n",
     "\n",
     "Trustworthiness is a measure of the extent to which the local structure is retained in the embedding of the model. Therefore, if a sample predicted by the model lay within the unexpected region of the nearest neighbors, then those samples would be penalized. For more information on the trustworthiness metric please refer to: https://scikit-learn.org/dev/modules/generated/sklearn.manifold.t_sne.trustworthiness.html\n",
     "\n",
-    "See the [trustworthiness API reference](api/generated/cuml.metrics.trustworthiness.html) for cuML's implementation of the metric.\n",
+    "See the [trustworthiness API reference](api/generated/cuml.metrics.trustworthiness.rst) for cuML's implementation of the metric.\n",
     "\n",
     "The cell below shows an end-to-end pipeline of the UMAP model. Here, the blobs dataset is created using cuML's make_blobs function to be used as the input. The output of UMAP's fit_transform is evaluated using cuML's trustworthiness function.\n"
    ]
@@ -134,7 +134,7 @@
    "metadata": {},
    "source": [
     "### DBSCAN and Adjusted Random Index\n",
-    "DBSCAN is a popular clustering algorithm. For additional information on the model, see the [DBSCAN API reference](api/generated/cuml.cluster.DBSCAN.html).\n",
+    "DBSCAN is a popular clustering algorithm. For additional information on the model, see the [DBSCAN API reference](api/generated/cuml.cluster.DBSCAN.rst).\n",
     "\n",
     "We create the blobs dataset using cuML's make_blobs function.\n",
     "\n",
@@ -190,9 +190,9 @@
     "R^2 score is also known as the coefficient of determination. It is used as a metric for scoring regression models. It scores the output of the model based on the proportion of total variation of the model.\n",
     "For more information on the R^2 score metrics please refer to: https://en.wikipedia.org/wiki/Coefficient_of_determination\n",
     "\n",
-    "For more information on cuML's implementation of the R² score metric, see the [R² score API reference](api/generated/cuml.metrics.r2_score.html).\n",
+    "For more information on cuML's implementation of the R² score metric, see the [R² score API reference](api/generated/cuml.metrics.r2_score.rst).\n",
     "\n",
-    "The cell below uses the Linear Regression model and evaluates its performance using cuML's R² score metric. See the [Linear Regression API reference](api/generated/cuml.linear_model.LinearRegression.html) for more information on cuML's implementation."
+    "The cell below uses the Linear Regression model and evaluates its performance using cuML's R² score metric. See the [Linear Regression API reference](api/generated/cuml.linear_model.LinearRegression.rst) for more information on cuML's implementation."
    ]
   },
   {

--- a/docs/source/estimator_intro.ipynb
+++ b/docs/source/estimator_intro.ipynb
@@ -33,12 +33,12 @@
     "### Random Forest Classification and Accuracy metrics\n",
     "\n",
     "The Random Forest classification model builds several decision trees, and aggregates each of their outputs to make a prediction. For more information on cuML's implementation of the Random Forest Classification model please refer to:\n",
-    "https://docs.rapids.ai/api/cuml/stable/api.html#cuml.ensemble.RandomForestClassifier\n",
+    "[Random Forest Classifier API reference](api/generated/cuml.ensemble.RandomForestClassifier.html)\n",
     "\n",
     "Accuracy score is the ratio of correct predictions to the total number of predictions. It is used to measure the performance of classification models.\n",
     "For more information on the accuracy score metric please refer to: https://en.wikipedia.org/wiki/Accuracy_and_precision\n",
     "\n",
-    "For more information on cuML's implementation of accuracy score metrics please refer to: https://docs.rapids.ai/api/cuml/stable/api.html#cuml.metrics.accuracy.accuracy_score\n",
+    "For more information on cuML's implementation of accuracy score metrics, see the [accuracy score API reference](api/generated/cuml.metrics.accuracy_score.html).\n",
     "\n",
     "The cell below shows an end-to-end pipeline of the Random Forest Classification model. Here the dataset was generated using cuML's make_classification dataset. The generated dataset was used to train and run predict on the model, and the performance is evaluated using cuML's accuracy metric."
    ]
@@ -91,11 +91,11 @@
    "source": [
     "### UMAP and Trustworthiness metrics\n",
     "UMAP is a dimensionality reduction algorithm which performs non-linear dimension reduction. It can also be used for visualization.\n",
-    "For additional information on the UMAP model please refer to the documentation on https://docs.rapids.ai/api/cuml/stable/api.html#cuml.UMAP\n",
+    "For additional information on the UMAP model, see the [UMAP API reference](api/generated/cuml.manifold.UMAP.html).\n",
     "\n",
     "Trustworthiness is a measure of the extent to which the local structure is retained in the embedding of the model. Therefore, if a sample predicted by the model lay within the unexpected region of the nearest neighbors, then those samples would be penalized. For more information on the trustworthiness metric please refer to: https://scikit-learn.org/dev/modules/generated/sklearn.manifold.t_sne.trustworthiness.html\n",
     "\n",
-    "The documentation for cuML's implementation of the trustworthiness metric is: https://docs.rapids.ai/api/cuml/stable/api.html#cuml.metrics.trustworthiness.trustworthiness\n",
+    "See the [trustworthiness API reference](api/generated/cuml.metrics.trustworthiness.html) for cuML's implementation of the metric.\n",
     "\n",
     "The cell below shows an end-to-end pipeline of the UMAP model. Here, the blobs dataset is created using cuML's make_blobs function to be used as the input. The output of UMAP's fit_transform is evaluated using cuML's trustworthiness function.\n"
    ]
@@ -134,7 +134,7 @@
    "metadata": {},
    "source": [
     "### DBSCAN and Adjusted Random Index\n",
-    "DBSCAN is a popular and a powerful clustering algorithm.  For additional information on the DBSCAN model please refer to the documentation on https://docs.rapids.ai/api/cuml/stable/api.html#cuml.DBSCAN\n",
+    "DBSCAN is a popular clustering algorithm. For additional information on the model, see the [DBSCAN API reference](api/generated/cuml.cluster.DBSCAN.html).\n",
     "\n",
     "We create the blobs dataset using cuML's make_blobs function.\n",
     "\n",
@@ -190,10 +190,9 @@
     "R^2 score is also known as the coefficient of determination. It is used as a metric for scoring regression models. It scores the output of the model based on the proportion of total variation of the model.\n",
     "For more information on the R^2 score metrics please refer to: https://en.wikipedia.org/wiki/Coefficient_of_determination\n",
     "\n",
-    "For more information on cuML's implementation of the r2 score metrics please refer to : https://docs.rapids.ai/api/cuml/stable/api.html#cuml.metrics.regression.r2_score\n",
+    "For more information on cuML's implementation of the R² score metric, see the [R² score API reference](api/generated/cuml.metrics.r2_score.html).\n",
     "\n",
-    "The cell below uses the Linear Regression model and evaluates its performance using cuML's R² score metric. For more information on cuML's implementation of the Linear Regression model please refer to : \n",
-    "https://docs.rapids.ai/api/cuml/stable/api.html#linear-regression"
+    "The cell below uses the Linear Regression model and evaluates its performance using cuML's R² score metric. See the [Linear Regression API reference](api/generated/cuml.linear_model.LinearRegression.html) for more information on cuML's implementation."
    ]
   },
   {

--- a/docs/source/index.rst
+++ b/docs/source/index.rst
@@ -56,13 +56,12 @@ visit the `RAPIDS Release Selector <https://docs.rapids.ai/install#selector>`_.
    `the RAPIDS install page <https://docs.rapids.ai/install/#system-req>`_
    for details on system and hardware requirements.
 
-Part of RAPIDS
-==============
+CUDA-X Data Science
+===================
 
-cuML is part of the RAPIDS suite of open source libraries that enable
-end-to-end data science and analytics pipelines entirely on GPUs. It works
-seamlessly with other RAPIDS libraries like cuDF for data manipulation and
-cuGraph for graph analytics.
+NVIDIA cuML is an open-source CUDA-X Data Science library for GPU-accelerated
+machine learning. It integrates with libraries in the broader RAPIDS ecosystem,
+including cuDF for data manipulation and cuGraph for graph analytics.
 
 Community & Support
 ===================
@@ -70,7 +69,7 @@ Community & Support
 * :doc:`User Guide <user_guide>` - Comprehensive usage documentation
 * :doc:`API Reference <api/index>` - Complete API documentation
 * `GitHub Issues <https://github.com/NVIDIA/cuml/issues>`_ - Report bugs and request features
-* `RAPIDS Community <https://rapids.ai/community.html>`_ - Join our community
+* `CUDA-X Data Science Community <https://developer.nvidia.com/topics/ai/data-science/cuda-x-for-data-science#join-the-community>`_ - Join our community
 
 .. toctree::
    :hidden:

--- a/docs/source/user_guide.rst
+++ b/docs/source/user_guide.rst
@@ -5,7 +5,7 @@ This section provides practical guidance on how to get started with cuML in your
 own projects to run classic ML algorithms blazingly fast on NVIDIA GPUs. You can
 simply read through the examples or try them out yourself. If you want to run
 code directly, have a look at the notebooks within the `notebooks
-<https://github.com/NVIDIA/cuml/tree/HEAD/notebooks>`_ as part of the cuML
+<https://github.com/NVIDIA/cuml/tree/main/notebooks>`_ as part of the cuML
 GitHub repository instead.
 
 .. note::


### PR DESCRIPTION
Updates cuML documentation with NVIDIA cuML and CUDA-X Data Science positioning, canonical NVIDIA documentation links, and Sphinx-relative self-links.

Follow-up to #8471

Closes #8470
