### PR TITLE
Add cuml.accel support for sklearn.ensemble.IsolationForest

### DIFF
--- a/cpp/include/cuml/ensemble/isolation_forest.hpp
+++ b/cpp/include/cuml/ensemble/isolation_forest.hpp
@@ -145,9 +145,12 @@ void fit(const raft::handle_t& handle,
  * @param[in]  n_rows          Number of training samples
  * @param[in]  n_cols          Number of features
  * @param[in]  params          Hyperparameters (n_estimators, max_samples, max_depth, seed)
- * @param[out] c_normalization Normalization constant c(n) for the trained forest, needed to
- *                             turn average path lengths into anomaly scores
- * @param[in]  verbosity       Logging level
+ * @param[out] c_normalization    Normalization constant c(n) for the trained forest, needed to
+ *                                turn average path lengths into anomaly scores
+ * @param[out] feature_indices    Host buffer receiving each tree's sampled feature indices in
+ *                                row-major [n_estimators, resolved max_features] order
+ * @param[in]  feature_indices_size Number of elements available in feature_indices
+ * @param[in]  verbosity          Logging level
  */
 template <typename T>
 void fit_treelite(const raft::handle_t& handle,
@@ -157,6 +160,8 @@ void fit_treelite(const raft::handle_t& handle,
                   int n_cols,
                   const IF_params& params,
                   double* c_normalization,
+                  int* feature_indices,
+                  size_t feature_indices_size,
                   rapids_logger::level_enum verbosity = rapids_logger::level_enum::info);
 
 /**

--- a/cpp/src/isolation_forest/isolation_forest.cu
+++ b/cpp/src/isolation_forest/isolation_forest.cu
@@ -5,6 +5,7 @@
 
 #include "isolation_forest.cuh"
 
+#include <cuml/common/checked_arithmetic.hpp>
 #include <cuml/ensemble/isolation_forest.hpp>
 
 #include <raft/core/error.hpp>
@@ -173,7 +174,7 @@ void fit_treelite(const raft::handle_t& handle,
   *c_normalization = forest.c_normalization;
 
   size_t expected_feature_indices =
-    static_cast<size_t>(forest.params.n_estimators) * forest.n_features_per_tree;
+    ML::checked_mul<std::size_t>(forest.params.n_estimators, forest.n_features_per_tree);
   ASSERT(feature_indices != nullptr || expected_feature_indices == 0,
          "Feature indices output buffer cannot be null.");
   ASSERT(feature_indices_size == expected_feature_indices,
@@ -183,17 +184,21 @@ void fit_treelite(const raft::handle_t& handle,
 
   if (forest.global_feature_indices.size() == 0) {
     for (int tree = 0; tree < forest.params.n_estimators; ++tree) {
+      // Bounded by expected_feature_indices (validated above), so the per-row
+      // base offset is computed once rather than checked on every write.
+      size_t row_offset = static_cast<size_t>(tree) * forest.n_features_per_tree;
       for (int feature = 0; feature < forest.n_features_per_tree; ++feature) {
-        feature_indices[static_cast<size_t>(tree) * forest.n_features_per_tree + feature] = feature;
+        feature_indices[row_offset + feature] = feature;
       }
     }
   } else {
     auto stream = handle.get_stream();
-    RAFT_CUDA_TRY(cudaMemcpyAsync(feature_indices,
-                                  forest.global_feature_indices.data(),
-                                  expected_feature_indices * sizeof(int),
-                                  cudaMemcpyDeviceToHost,
-                                  stream));
+    RAFT_CUDA_TRY(
+      cudaMemcpyAsync(feature_indices,
+                      forest.global_feature_indices.data(),
+                      ML::checked_mul<std::size_t>(expected_feature_indices, sizeof(int)),
+                      cudaMemcpyDeviceToHost,
+                      stream));
     handle.sync_stream(stream);
   }
 

--- a/cpp/src/isolation_forest/isolation_forest.cu
+++ b/cpp/src/isolation_forest/isolation_forest.cu
@@ -9,6 +9,7 @@
 
 #include <raft/core/error.hpp>
 #include <raft/core/handle.hpp>
+#include <raft/util/cudart_utils.hpp>
 
 #include <rmm/device_uvector.hpp>
 #include <rmm/exec_policy.hpp>
@@ -161,6 +162,8 @@ void fit_treelite(const raft::handle_t& handle,
                   int n_cols,
                   const IF_params& params,
                   double* c_normalization,
+                  int* feature_indices,
+                  size_t feature_indices_size,
                   rapids_logger::level_enum verbosity)
 {
   ASSERT(c_normalization != nullptr, "Normalization output pointer cannot be null.");
@@ -168,6 +171,32 @@ void fit_treelite(const raft::handle_t& handle,
   IsolationForestModel<T> forest;
   fit(handle, &forest, input, n_rows, n_cols, params, verbosity);
   *c_normalization = forest.c_normalization;
+
+  size_t expected_feature_indices =
+    static_cast<size_t>(forest.params.n_estimators) * forest.n_features_per_tree;
+  ASSERT(feature_indices != nullptr || expected_feature_indices == 0,
+         "Feature indices output buffer cannot be null.");
+  ASSERT(feature_indices_size == expected_feature_indices,
+         "Expected feature indices output buffer of size %zu, got %zu.",
+         expected_feature_indices,
+         feature_indices_size);
+
+  if (forest.global_feature_indices.size() == 0) {
+    for (int tree = 0; tree < forest.params.n_estimators; ++tree) {
+      for (int feature = 0; feature < forest.n_features_per_tree; ++feature) {
+        feature_indices[static_cast<size_t>(tree) * forest.n_features_per_tree + feature] = feature;
+      }
+    }
+  } else {
+    auto stream = handle.get_stream();
+    RAFT_CUDA_TRY(cudaMemcpyAsync(feature_indices,
+                                  forest.global_feature_indices.data(),
+                                  expected_feature_indices * sizeof(int),
+                                  cudaMemcpyDeviceToHost,
+                                  stream));
+    handle.sync_stream(stream);
+  }
+
   build_treelite_isolation_forest<T>(model_handle, handle, &forest);
 }
 
@@ -273,6 +302,8 @@ template CUML_EXPORT void fit_treelite<float>(const raft::handle_t&,
                                               int,
                                               const IF_params&,
                                               double*,
+                                              int*,
+                                              size_t,
                                               rapids_logger::level_enum);
 template CUML_EXPORT void fit_treelite<double>(const raft::handle_t&,
                                                TreeliteModelHandle*,
@@ -281,6 +312,8 @@ template CUML_EXPORT void fit_treelite<double>(const raft::handle_t&,
                                                int,
                                                const IF_params&,
                                                double*,
+                                               int*,
+                                               size_t,
                                                rapids_logger::level_enum);
 
 }  // namespace ML

--- a/cpp/src/isolation_forest/isolation_forest.cu
+++ b/cpp/src/isolation_forest/isolation_forest.cu
@@ -193,12 +193,10 @@ void fit_treelite(const raft::handle_t& handle,
     }
   } else {
     auto stream = handle.get_stream();
-    RAFT_CUDA_TRY(
-      cudaMemcpyAsync(feature_indices,
-                      forest.global_feature_indices.data(),
-                      ML::checked_mul<std::size_t>(expected_feature_indices, sizeof(int)),
-                      cudaMemcpyDeviceToHost,
-                      stream));
+    raft::copy(feature_indices,
+               static_cast<const int*>(forest.global_feature_indices.data()),
+               expected_feature_indices,
+               stream);
     handle.sync_stream(stream);
   }
 

--- a/cpp/tests/sg/isolation_forest_test.cu
+++ b/cpp/tests/sg/isolation_forest_test.cu
@@ -482,6 +482,128 @@ TEST_F(IsolationForestTest, MaxFeaturesFitStoresOriginalFeatureIds)
   EXPECT_EQ(model.global_feature_indices.size(), 0);
 }
 
+TEST_F(IsolationForestTest, FitTreeliteReturnsSampledFeatureIds)
+{
+  const int n_samples    = 128;
+  const int n_features   = 8;
+  const int n_estimators = 5;
+  const int max_features = 3;
+
+  thrust::device_vector<float> X_rowmajor(n_samples * n_features);
+  thrust::device_vector<float> X_colmajor(n_samples * n_features);
+  raft::random::Rng rng(42);
+  rng.normal(X_rowmajor.data().get(), X_rowmajor.size(), 0.0f, 1.0f, stream);
+  handle->sync_stream(stream);
+  transpose_data(X_rowmajor, X_colmajor, n_samples, n_features);
+
+  IF_params params;
+  params.n_estimators = n_estimators;
+  params.max_samples  = 64;
+  params.max_features = max_features;
+  params.seed         = 42;
+
+  std::vector<int> feature_indices(static_cast<size_t>(n_estimators) * max_features);
+  TreeliteModelHandle tl_handle = nullptr;
+  double c_normalization        = 0.0;
+  fit_treelite(*handle,
+               &tl_handle,
+               X_colmajor.data().get(),
+               n_samples,
+               n_features,
+               params,
+               &c_normalization,
+               feature_indices.data(),
+               feature_indices.size());
+  ASSERT_NE(tl_handle, nullptr);
+  delete static_cast<tl::Model*>(tl_handle);
+
+  for (int tree = 0; tree < n_estimators; ++tree) {
+    auto first = feature_indices.begin() + static_cast<size_t>(tree) * max_features;
+    auto last  = first + max_features;
+    for (auto it = first; it != last; ++it) {
+      EXPECT_GE(*it, 0);
+      EXPECT_LT(*it, n_features);
+    }
+    std::vector<int> sorted(first, last);
+    std::sort(sorted.begin(), sorted.end());
+    EXPECT_EQ(std::unique(sorted.begin(), sorted.end()), sorted.end());
+  }
+}
+
+TEST_F(IsolationForestTest, FitTreeliteValidatesFeatureBufferSize)
+{
+  const int n_samples  = 32;
+  const int n_features = 4;
+
+  thrust::device_vector<float> X_rowmajor(n_samples * n_features);
+  thrust::device_vector<float> X_colmajor(n_samples * n_features);
+  raft::random::Rng rng(42);
+  rng.normal(X_rowmajor.data().get(), X_rowmajor.size(), 0.0f, 1.0f, stream);
+  handle->sync_stream(stream);
+  transpose_data(X_rowmajor, X_colmajor, n_samples, n_features);
+
+  IF_params params;
+  params.n_estimators = 2;
+  params.max_samples  = 16;
+  params.max_features = 2;
+
+  std::vector<int> feature_indices(3);
+  TreeliteModelHandle tl_handle = nullptr;
+  double c_normalization        = 0.0;
+  EXPECT_THROW(fit_treelite(*handle,
+                            &tl_handle,
+                            X_colmajor.data().get(),
+                            n_samples,
+                            n_features,
+                            params,
+                            &c_normalization,
+                            feature_indices.data(),
+                            feature_indices.size()),
+               raft::exception);
+  EXPECT_EQ(tl_handle, nullptr);
+}
+
+TEST_F(IsolationForestTest, FitTreeliteReturnsFullFeatureRange)
+{
+  const int n_samples    = 32;
+  const int n_features   = 4;
+  const int n_estimators = 2;
+
+  thrust::device_vector<float> X_rowmajor(n_samples * n_features);
+  thrust::device_vector<float> X_colmajor(n_samples * n_features);
+  raft::random::Rng rng(42);
+  rng.normal(X_rowmajor.data().get(), X_rowmajor.size(), 0.0f, 1.0f, stream);
+  handle->sync_stream(stream);
+  transpose_data(X_rowmajor, X_colmajor, n_samples, n_features);
+
+  IF_params params;
+  params.n_estimators = n_estimators;
+  params.max_samples  = 16;
+  params.max_features = n_features;
+  params.seed         = 42;
+
+  std::vector<int> feature_indices(static_cast<size_t>(n_estimators) * n_features);
+  TreeliteModelHandle tl_handle = nullptr;
+  double c_normalization        = 0.0;
+  fit_treelite(*handle,
+               &tl_handle,
+               X_colmajor.data().get(),
+               n_samples,
+               n_features,
+               params,
+               &c_normalization,
+               feature_indices.data(),
+               feature_indices.size());
+  ASSERT_NE(tl_handle, nullptr);
+  delete static_cast<tl::Model*>(tl_handle);
+
+  for (int tree = 0; tree < n_estimators; ++tree) {
+    for (int feature = 0; feature < n_features; ++feature) {
+      EXPECT_EQ(feature_indices[static_cast<size_t>(tree) * n_features + feature], feature);
+    }
+  }
+}
+
 TEST_F(IsolationForestTest, ConstantFeaturesDoNotStopSplitting)
 {
   const int n_samples    = 64;

--- a/docs/source/cuml-accel/compatibility.rst
+++ b/docs/source/cuml-accel/compatibility.rst
@@ -225,6 +225,26 @@ To compare results between estimators, we recommend comparing scores like
    - If ``y`` is a multi-output target.
 
 
+.. dropdown:: ``IsolationForest``
+   :name: isolationforest
+
+   ``IsolationForest`` will fall back to CPU in the following cases:
+
+   - If ``warm_start=True``.
+   - If ``sample_weight`` is passed to ``fit`` or ``fit_predict``.
+   - If ``X`` is sparse.
+   - If ``X`` contains missing or non-finite values.
+
+   Additional notes:
+
+   - Conversion of a fitted GPU ``IsolationForest`` back to a CPU estimator
+     is supported. Accessing fit attributes (``offset_``, ``max_samples_``,
+     ``estimators_``, and others) or pickling a GPU-fitted model triggers
+     this conversion automatically.
+   - ``estimators_samples_`` is not available on the converted model,
+     since cuML does not record per-tree sample indices.
+
+
 sklearn.kernel_ridge
 ~~~~~~~~~~~~~~~~~~~~
 

--- a/docs/source/cuml-accel/compatibility.rst
+++ b/docs/source/cuml-accel/compatibility.rst
@@ -231,18 +231,14 @@ To compare results between estimators, we recommend comparing scores like
    ``IsolationForest`` will fall back to CPU in the following cases:
 
    - If ``warm_start=True``.
-   - If ``sample_weight`` is passed to ``fit`` or ``fit_predict``.
+   - If a non-``None`` ``sample_weight`` is passed to ``fit`` or
+     ``fit_predict``.
    - If ``X`` is sparse.
    - If ``X`` contains missing or non-finite values.
 
-   Additional notes:
+   Additionally, the following fitted attributes are currently not computed:
 
-   - Conversion of a fitted GPU ``IsolationForest`` back to a CPU estimator
-     is supported. Accessing fit attributes (``offset_``, ``max_samples_``,
-     ``estimators_``, and others) or pickling a GPU-fitted model triggers
-     this conversion automatically.
-   - ``estimators_samples_`` is not available on the converted model,
-     since cuML does not record per-tree sample indices.
+   - ``estimators_samples_``
 
 
 sklearn.kernel_ridge

--- a/python/cuml/cuml/accel/_overrides/sklearn/ensemble.py
+++ b/python/cuml/cuml/accel/_overrides/sklearn/ensemble.py
@@ -3,6 +3,8 @@
 # SPDX-License-Identifier: Apache-2.0
 #
 
+import numpy as np
+
 import cuml.ensemble
 from cuml.accel.estimator_proxy import ProxyBase
 from cuml.internals.interop import UnsupportedOnGPU
@@ -134,8 +136,8 @@ class IsolationForest(ProxyBase):
 
     def _gpu_decision_function(self, X):
         self._validate_input(X)
-        return self._gpu.decision_function(X)
+        return self._gpu.decision_function(X).astype(np.float64)
 
     def _gpu_score_samples(self, X):
         self._validate_input(X)
-        return self._gpu.score_samples(X)
+        return self._gpu.score_samples(X).astype(np.float64)

--- a/python/cuml/cuml/accel/_overrides/sklearn/ensemble.py
+++ b/python/cuml/cuml/accel/_overrides/sklearn/ensemble.py
@@ -102,16 +102,18 @@ class IsolationForest(ProxyBase):
 
     @staticmethod
     def _validate_input(X):
-        # cuML's IsolationForest requires dense, finite input and raises
-        # ValueError (NaN/inf) or TypeError (sparse) otherwise. Convert
-        # those into UnsupportedOnGPU so callers fall back to CPU instead
-        # of crashing.
+        # Sparse inputs are handled by ProxyBase before dispatch. Fall back only
+        # for non-finite dense inputs, which scikit-learn supports but cuML does
+        # not, and preserve unrelated validation errors.
         try:
             check_array(
                 X, mem_type=None, order=None, ensure_2d=False, input_name="X"
             )
-        except (ValueError, TypeError) as exc:
-            raise UnsupportedOnGPU(str(exc)) from None
+        except ValueError as exc:
+            message = str(exc)
+            if "contains NaN" in message or "contains infinity" in message:
+                raise UnsupportedOnGPU(message) from None
+            raise
 
     def _gpu_fit(self, X, y=None, sample_weight=None):
         self._validate_input(X)
@@ -126,8 +128,13 @@ class IsolationForest(ProxyBase):
         # (rather than declaring sample_weight explicitly) so the proxy stays
         # signature-compatible with the CPU method.
         self._validate_input(X)
-        if kwargs.get("sample_weight") is not None:
+        sample_weight = kwargs.pop("sample_weight", None)
+        if sample_weight is not None:
             raise UnsupportedOnGPU("sample_weight is not supported")
+        if kwargs:
+            raise UnsupportedOnGPU(
+                "Additional fit parameters are not supported"
+            )
         return self._gpu.fit_predict(X, y=y)
 
     def _gpu_predict(self, X):

--- a/python/cuml/cuml/accel/_overrides/sklearn/ensemble.py
+++ b/python/cuml/cuml/accel/_overrides/sklearn/ensemble.py
@@ -1,5 +1,5 @@
 #
-# SPDX-FileCopyrightText: Copyright (c) 2025-2026, NVIDIA CORPORATION.
+# SPDX-FileCopyrightText: Copyright (c) 2025-2026, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
 # SPDX-License-Identifier: Apache-2.0
 #
 
@@ -8,7 +8,11 @@ from cuml.accel.estimator_proxy import ProxyBase
 from cuml.internals.interop import UnsupportedOnGPU
 from cuml.internals.validation import check_array
 
-__all__ = ("RandomForestRegressor", "RandomForestClassifier")
+__all__ = (
+    "IsolationForest",
+    "RandomForestClassifier",
+    "RandomForestRegressor",
+)
 
 
 class _RandomForestMixin:
@@ -88,3 +92,50 @@ class RandomForestClassifier(ProxyBase, _RandomForestMixin):
 
     def __getitem__(self, index):
         return self._call_method("__getitem__", index)
+
+
+class IsolationForest(ProxyBase):
+    _gpu_class = cuml.ensemble.IsolationForest
+    _other_attributes = frozenset(("_max_samples",))
+
+    @staticmethod
+    def _validate_input(X):
+        # cuML's IsolationForest requires dense, finite input and raises
+        # ValueError (NaN/inf) or TypeError (sparse) otherwise. Convert
+        # those into UnsupportedOnGPU so callers fall back to CPU instead
+        # of crashing.
+        try:
+            check_array(
+                X, mem_type=None, order=None, ensure_2d=False, input_name="X"
+            )
+        except (ValueError, TypeError) as exc:
+            raise UnsupportedOnGPU(str(exc)) from None
+
+    def _gpu_fit(self, X, y=None, sample_weight=None):
+        self._validate_input(X)
+        if sample_weight is not None:
+            raise UnsupportedOnGPU("sample_weight is not supported")
+        return self._gpu.fit(X, y=y)
+
+    def _gpu_fit_predict(self, X, y=None, **kwargs):
+        # IsolationForest.fit_predict() doesn't declare sample_weight itself;
+        # it inherits OutlierMixin.fit_predict(self, X, y=None, **kwargs),
+        # which forwards kwargs straight to fit(). Match that signature here
+        # (rather than declaring sample_weight explicitly) so the proxy stays
+        # signature-compatible with the CPU method.
+        self._validate_input(X)
+        if kwargs.get("sample_weight") is not None:
+            raise UnsupportedOnGPU("sample_weight is not supported")
+        return self._gpu.fit_predict(X, y=y)
+
+    def _gpu_predict(self, X):
+        self._validate_input(X)
+        return self._gpu.predict(X)
+
+    def _gpu_decision_function(self, X):
+        self._validate_input(X)
+        return self._gpu.decision_function(X)
+
+    def _gpu_score_samples(self, X):
+        self._validate_input(X)
+        return self._gpu.score_samples(X)

--- a/python/cuml/cuml/ensemble/isolation_forest.pyx
+++ b/python/cuml/cuml/ensemble/isolation_forest.pyx
@@ -62,6 +62,8 @@ cdef extern from "cuml/ensemble/isolation_forest.hpp" namespace "ML" nogil:
         int n_cols,
         const IF_params& params,
         double* c_normalization,
+        int* feature_indices,
+        size_t feature_indices_size,
         level_enum verbosity
     ) except +
 
@@ -151,10 +153,13 @@ def _recover_node_sample_counts(tree, n_samples):
     return counts
 
 
-def _isolation_tree_to_sklearn(exported_tree, n_features, n_samples, max_depth):
+def _isolation_tree_to_sklearn(
+    exported_tree, feature_indices, n_samples, max_depth
+):
     """Rebuilds one fitted sklearn ``ExtraTreeRegressor`` from one tree of the
-    Treelite export, restoring the per-node sample counts that isolation
-    forest scoring requires."""
+    Treelite export, restoring per-node sample counts and remapping global
+    feature ids to the sampled subset used by sklearn's bagging representation.
+    """
     import sklearn
     from packaging.version import Version
     from sklearn.tree import ExtraTreeRegressor
@@ -164,7 +169,25 @@ def _isolation_tree_to_sklearn(exported_tree, n_features, n_samples, max_depth):
     nodes = state["nodes"].copy()
     nodes["n_node_samples"] = counts
     nodes["weighted_n_node_samples"] = counts.astype(np.float64)
-    rebuilt = ExtraTreeRegressor(max_features=1.0, max_depth=max_depth)
+
+    feature_indices = np.asarray(feature_indices, dtype=np.int64)
+    inverse = {
+        int(global_feature): local_feature
+        for local_feature, global_feature in enumerate(feature_indices)
+    }
+    split_nodes = nodes["feature"] >= 0
+    try:
+        nodes["feature"][split_nodes] = [
+            inverse[int(feature)] for feature in nodes["feature"][split_nodes]
+        ]
+    except KeyError as exc:
+        raise ValueError(
+            f"Exported tree uses feature {exc.args[0]}, which is not present "
+            "in its recorded sampled feature subset."
+        ) from None
+
+    n_features = len(feature_indices)
+    rebuilt = ExtraTreeRegressor(max_features=1, max_depth=max_depth)
     rebuilt.n_features_in_ = n_features
     rebuilt.n_outputs_ = 1
     tree_args = (n_features, np.asarray([1], dtype=np.intp), 1)
@@ -317,6 +340,7 @@ class IsolationForest(InteropMixin, CMajorInputTagMixin, Base):
         self.bootstrap = bootstrap
         self.random_state = random_state
         self.contamination = contamination
+        self._feature_indices = None
 
     @classmethod
     def _get_param_names(cls):
@@ -365,38 +389,53 @@ class IsolationForest(InteropMixin, CMajorInputTagMixin, Base):
     def _attrs_to_cpu(self, model):
         """Converts fitted state to sklearn attributes.
 
-        The tree structure comes from the Treelite export; the per-node sample
-        counts that isolation forest scoring requires are recovered from the
-        leaf values (see ``_invert_average_path_length``). ``_seeds`` is not
-        transferable because cuML does not record per-tree sample indices, so
-        ``estimators_samples_`` is unavailable on the converted model.
+        A fresh tree snapshot is built for every conversion so mutations of
+        native inspection attributes never leak into converted models.
+        ``_seeds`` is not transferable because cuML does not record per-tree
+        sample indices, so ``estimators_samples_`` remains unavailable.
         """
         from sklearn.ensemble._iforest import _average_path_length
         from sklearn.tree import ExtraTreeRegressor
 
+        check_is_fitted(self)
         tl_model = treelite.Model.deserialize_bytes(self._treelite_model_bytes)
         exported = treelite.sklearn.export_model(tl_model)
-        n_features = self.n_features_in_
         n_samples = int(self.max_samples_)
         if self.max_depth is None:
             max_depth = int(np.ceil(np.log2(max(n_samples, 2))))
         else:
             max_depth = int(self.max_depth)
+
+        feature_indices = np.asarray(self._feature_indices, dtype=np.int64)
+        if (
+            feature_indices.ndim != 2
+            or feature_indices.shape[0] != len(exported.estimators_)
+            or feature_indices.shape[1] != self._max_features
+        ):
+            raise ValueError(
+                "Stored feature indices do not match the fitted forest shape."
+            )
         estimators = [
-            _isolation_tree_to_sklearn(tree, n_features, n_samples, max_depth)
-            for tree in exported.estimators_
+            _isolation_tree_to_sklearn(
+                tree, features, n_samples, max_depth
+            )
+            for tree, features in zip(
+                exported.estimators_, feature_indices, strict=True
+            )
         ]
         return {
-            "estimator_": ExtraTreeRegressor(max_features=1.0),
+            "estimator_": ExtraTreeRegressor(
+                max_features=1,
+                max_depth=max_depth,
+                random_state=self.random_state,
+            ),
             "estimators_": estimators,
             "estimators_features_": [
-                np.arange(n_features, dtype=np.int64) for _ in estimators
+                features.copy() for features in feature_indices
             ],
             "max_samples_": n_samples,
             "offset_": float(self.offset_),
-            # The exported trees reference features globally, so scoring uses
-            # the full feature set for every tree.
-            "_max_features": n_features,
+            "_max_features": self._max_features,
             "_max_samples": n_samples,
             "_sample_weight": None,
             "_average_path_length_per_tree": tuple(
@@ -561,6 +600,12 @@ class IsolationForest(InteropMixin, CMajorInputTagMixin, Base):
         params.bootstrap = self.bootstrap
         params.seed = seed
 
+        feature_indices = np.empty(
+            (self.n_estimators, actual_max_features), dtype=np.int32
+        )
+        cdef uintptr_t feature_indices_ptr = <uintptr_t>feature_indices.ctypes.data
+        cdef size_t feature_indices_size = feature_indices.size
+
         # Get handle and verbosity
         handle = get_handle()
         cdef handle_t* handle_ = <handle_t*><uintptr_t>handle.getHandle()
@@ -584,6 +629,8 @@ class IsolationForest(InteropMixin, CMajorInputTagMixin, Base):
                         n_cols,
                         params,
                         &c_normalization,
+                        <int*>feature_indices_ptr,
+                        feature_indices_size,
                         verbose,
                     )
                 else:
@@ -595,6 +642,8 @@ class IsolationForest(InteropMixin, CMajorInputTagMixin, Base):
                         n_cols,
                         params,
                         &c_normalization,
+                        <int*>feature_indices_ptr,
+                        feature_indices_size,
                         verbose,
                     )
 
@@ -618,6 +667,8 @@ class IsolationForest(InteropMixin, CMajorInputTagMixin, Base):
 
         self._treelite_model_bytes = <bytes>(tl_bytes[:tl_bytes_len])
         self._normalization_constant = c_normalization
+        self._max_features = actual_max_features
+        self._feature_indices = feature_indices
         # Load the inference model here rather than on first use, so that
         # `predict` and friends don't mutate the estimator. The lazy path in
         # `_get_inference_nvforest_model` then only covers unpickled models.

--- a/python/cuml/cuml/ensemble/isolation_forest.pyx
+++ b/python/cuml/cuml/ensemble/isolation_forest.pyx
@@ -741,8 +741,7 @@ class IsolationForest(InteropMixin, CMajorInputTagMixin, Base):
 
         This helper intentionally excludes input validation so ``fit`` can
         score its already validated training data while computing a non-auto
-        contamination threshold. Public inference methods validate before
-        calling it.
+        contamination threshold. Public inference validates in ``score_samples``.
         """
         nvforest_model = self._get_inference_nvforest_model()
         dtype = nvforest_model.forest.get_dtype()
@@ -825,15 +824,7 @@ class IsolationForest(InteropMixin, CMajorInputTagMixin, Base):
         scores : ndarray of shape (n_samples,)
             The decision function. Negative values indicate anomalies.
         """
-        check_is_fitted(self)
-        nvforest_model = self._get_inference_nvforest_model()
-        X_m = check_inputs(
-            self,
-            X,
-            dtype=nvforest_model.forest.get_dtype(),
-            order="C",
-        )
-        return self._score_samples(X_m) - self.offset_
+        return self.score_samples(X) - self.offset_
 
     @mlfunc(preserve_index=True)
     def predict(self, X):
@@ -852,17 +843,8 @@ class IsolationForest(InteropMixin, CMajorInputTagMixin, Base):
         labels : ndarray of shape (n_samples,)
             1 for inliers, -1 for outliers.
         """
-        check_is_fitted(self)
-        nvforest_model = self._get_inference_nvforest_model()
-        X_m = check_inputs(
-            self,
-            X,
-            dtype=nvforest_model.forest.get_dtype(),
-            order="C",
-        )
-
         # ``decision_function(X) < 0`` rearranged to avoid materializing it.
-        return cp.where(self._score_samples(X_m) < self.offset_, -1, 1)
+        return cp.where(self.score_samples(X) < self.offset_, -1, 1)
 
     @mlfunc(preserve_index=True)
     def fit_predict(self, X, y=None):

--- a/python/cuml/cuml/ensemble/isolation_forest.pyx
+++ b/python/cuml/cuml/ensemble/isolation_forest.pyx
@@ -176,6 +176,10 @@ def _isolation_tree_to_sklearn(
         for local_feature, global_feature in enumerate(feature_indices)
     }
     split_nodes = nodes["feature"] >= 0
+    # Preserve native ``<`` splits with sklearn's ``<=`` tree traversal.
+    nodes["threshold"][split_nodes] = np.nextafter(
+        nodes["threshold"][split_nodes], -np.inf
+    )
     try:
         nodes["feature"][split_nodes] = [
             inverse[int(feature)] for feature in nodes["feature"][split_nodes]

--- a/python/cuml/cuml/ensemble/isolation_forest.pyx
+++ b/python/cuml/cuml/ensemble/isolation_forest.pyx
@@ -624,7 +624,9 @@ class IsolationForest(InteropMixin, CMajorInputTagMixin, Base):
         self._nvforest_model = self.as_nvforest()
 
         if use_contamination_quantile:
-            training_scores = self.score_samples(X_m)
+            # Score the already transferred training data directly. nvForest
+            # normalizes the device-array layout during prediction.
+            training_scores = self._score_samples(X_m)
             self.offset_ = float(
                 cp.percentile(
                     training_scores, 100.0 * contamination_fraction
@@ -677,23 +679,10 @@ class IsolationForest(InteropMixin, CMajorInputTagMixin, Base):
             self._nvforest_model = nvforest_model = self.as_nvforest()
         return nvforest_model
 
-    def _score_samples(self, X):
-        """
-        Compute anomaly scores through nvForest inference.
-
-        Shared by ``score_samples``, ``decision_function`` and ``predict`` so
-        that input validation runs exactly once per public call.
-        """
+    def _score_samples(self, X_m):
+        """Compute anomaly scores from validated device input."""
         nvforest_model = self._get_inference_nvforest_model()
         dtype = nvforest_model.forest.get_dtype()
-
-        # Convert input to a row-major device array for inference.
-        X_m = check_inputs(
-            self,
-            X,
-            dtype=dtype,
-            order="C",
-        )
 
         # Each exported leaf holds ``depth + c(n_node_samples)`` and the model
         # averages leaf values across trees, so this is E[h(x)].
@@ -746,8 +735,14 @@ class IsolationForest(InteropMixin, CMajorInputTagMixin, Base):
             ``offset_`` are predicted as anomalies.
         """
         check_is_fitted(self)
-
-        return self._score_samples(X)
+        nvforest_model = self._get_inference_nvforest_model()
+        X_m = check_inputs(
+            self,
+            X,
+            dtype=nvforest_model.forest.get_dtype(),
+            order="C",
+        )
+        return self._score_samples(X_m)
 
     @mlfunc(preserve_index=True)
     def decision_function(self, X):
@@ -768,8 +763,14 @@ class IsolationForest(InteropMixin, CMajorInputTagMixin, Base):
             The decision function. Negative values indicate anomalies.
         """
         check_is_fitted(self)
-
-        return self._score_samples(X) - self.offset_
+        nvforest_model = self._get_inference_nvforest_model()
+        X_m = check_inputs(
+            self,
+            X,
+            dtype=nvforest_model.forest.get_dtype(),
+            order="C",
+        )
+        return self._score_samples(X_m) - self.offset_
 
     @mlfunc(preserve_index=True)
     def predict(self, X):
@@ -789,9 +790,16 @@ class IsolationForest(InteropMixin, CMajorInputTagMixin, Base):
             1 for inliers, -1 for outliers.
         """
         check_is_fitted(self)
+        nvforest_model = self._get_inference_nvforest_model()
+        X_m = check_inputs(
+            self,
+            X,
+            dtype=nvforest_model.forest.get_dtype(),
+            order="C",
+        )
 
         # ``decision_function(X) < 0`` rearranged to avoid materializing it.
-        return cp.where(self._score_samples(X) < self.offset_, -1, 1)
+        return cp.where(self._score_samples(X_m) < self.offset_, -1, 1)
 
     @mlfunc(preserve_index=True)
     def fit_predict(self, X, y=None):

--- a/python/cuml/cuml/ensemble/isolation_forest.pyx
+++ b/python/cuml/cuml/ensemble/isolation_forest.pyx
@@ -624,8 +624,10 @@ class IsolationForest(InteropMixin, CMajorInputTagMixin, Base):
         self._nvforest_model = self.as_nvforest()
 
         if use_contamination_quantile:
-            # Score the already transferred training data directly. nvForest
-            # normalizes the device-array layout during prediction.
+            # Score the already validated training data directly. Calling the
+            # public method would validate again after fit has recorded
+            # feature_names_in_, causing a spurious warning for DataFrame input
+            # because X_m no longer carries those names.
             training_scores = self._score_samples(X_m)
             self.offset_ = float(
                 cp.percentile(
@@ -680,7 +682,13 @@ class IsolationForest(InteropMixin, CMajorInputTagMixin, Base):
         return nvforest_model
 
     def _score_samples(self, X_m):
-        """Compute anomaly scores from validated device input."""
+        """Compute anomaly scores from validated device input.
+
+        This helper intentionally excludes input validation so ``fit`` can
+        score its already validated training data while computing a non-auto
+        contamination threshold. Public inference methods validate before
+        calling it.
+        """
         nvforest_model = self._get_inference_nvforest_model()
         dtype = nvforest_model.forest.get_dtype()
 

--- a/python/cuml/cuml_accel_tests/integration/test_isolation_forest.py
+++ b/python/cuml/cuml_accel_tests/integration/test_isolation_forest.py
@@ -1,0 +1,104 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+import pickle
+
+import numpy as np
+import pytest
+from sklearn.datasets import make_blobs
+from sklearn.ensemble import IsolationForest
+
+CPUIsolationForest = IsolationForest._cpu_class
+
+
+@pytest.fixture(scope="module")
+def blobs_with_outliers():
+    X, _ = make_blobs(
+        n_samples=200,
+        centers=1,
+        cluster_std=0.5,
+        random_state=42,
+    )
+    rng = np.random.RandomState(42)
+    outliers = rng.uniform(low=-10, high=10, size=(20, X.shape[1]))
+    return np.vstack([X, outliers])
+
+
+def test_isolation_forest_fit_predict_agreement(blobs_with_outliers):
+    X = blobs_with_outliers
+    params = {"n_estimators": 100, "random_state": 0}
+
+    expected = CPUIsolationForest(**params).fit(X)
+    result = IsolationForest(**params).fit(X)
+
+    assert result._gpu is not None
+
+    expected_labels = expected.predict(X)
+    result_labels = result.predict(X)
+    assert set(np.unique(result_labels)) <= {-1, 1}
+    assert np.mean(expected_labels == result_labels) >= 0.9
+
+
+def test_isolation_forest_fit_sample_weight_falls_back_to_cpu(
+    blobs_with_outliers,
+):
+    # cuml.ensemble.IsolationForest.fit() has no sample_weight parameter,
+    # so a non-None sample_weight cannot be honored on GPU.
+    X = blobs_with_outliers
+    sample_weight = np.ones(len(X))
+
+    result = IsolationForest(n_estimators=10, random_state=0).fit(
+        X, sample_weight=sample_weight
+    )
+
+    assert result._gpu is None
+
+
+def test_isolation_forest_fit_predict_sample_weight_falls_back_to_cpu(
+    blobs_with_outliers,
+):
+    # Same as above, for fit_predict().
+    X = blobs_with_outliers
+    sample_weight = np.ones(len(X))
+
+    result = IsolationForest(n_estimators=10, random_state=0)
+    result.fit_predict(X, sample_weight=sample_weight)
+
+    assert result._gpu is None
+
+
+def test_isolation_forest_gpu_methods_and_attrs(blobs_with_outliers):
+    """GPU methods and synchronized sklearn attributes remain equivalent."""
+    X = blobs_with_outliers
+    result = IsolationForest(n_estimators=50, random_state=0).fit(X)
+    assert result._gpu is not None
+
+    scores = result.score_samples(X)
+    decisions = result.decision_function(X)
+    np.testing.assert_allclose(decisions, scores - result._gpu.offset_)
+
+    assert len(result.estimators_) == 50
+    assert len(result.estimators_features_) == 50
+    assert result.offset_ == pytest.approx(float(result._gpu.offset_))
+    assert result._max_samples == result.max_samples_
+    np.testing.assert_allclose(
+        result._cpu.decision_function(X), decisions, atol=1e-5
+    )
+
+    with pytest.raises(AttributeError):
+        result.estimators_samples_
+
+
+def test_isolation_forest_pickle_roundtrip(blobs_with_outliers):
+    """A GPU-fitted proxy pickles through its synchronized CPU estimator."""
+    X = blobs_with_outliers
+    result = IsolationForest(n_estimators=20, random_state=0).fit(X)
+    expected_scores = result.score_samples(X)
+    expected_predictions = result.predict(X)
+
+    restored = pickle.loads(pickle.dumps(result))
+
+    np.testing.assert_allclose(
+        restored.score_samples(X), expected_scores, atol=1e-5
+    )
+    np.testing.assert_array_equal(restored.predict(X), expected_predictions)

--- a/python/cuml/cuml_accel_tests/integration/test_isolation_forest.py
+++ b/python/cuml/cuml_accel_tests/integration/test_isolation_forest.py
@@ -75,6 +75,8 @@ def test_isolation_forest_gpu_methods_and_attrs(blobs_with_outliers):
 
     scores = result.score_samples(X)
     decisions = result.decision_function(X)
+    assert scores.dtype == np.float64
+    assert decisions.dtype == np.float64
     np.testing.assert_allclose(decisions, scores - result._gpu.offset_)
 
     assert len(result.estimators_) == 50

--- a/python/cuml/cuml_accel_tests/integration/test_isolation_forest.py
+++ b/python/cuml/cuml_accel_tests/integration/test_isolation_forest.py
@@ -24,7 +24,7 @@ def blobs_with_outliers():
     return np.vstack([X, outliers])
 
 
-def test_isolation_forest_fit_predict_agreement(blobs_with_outliers):
+def test_isolation_forest_fit_and_predict_agreement(blobs_with_outliers):
     X = blobs_with_outliers
     params = {"n_estimators": 100, "random_state": 0}
 
@@ -37,6 +37,30 @@ def test_isolation_forest_fit_predict_agreement(blobs_with_outliers):
     result_labels = result.predict(X)
     assert set(np.unique(result_labels)) <= {-1, 1}
     assert np.mean(expected_labels == result_labels) >= 0.9
+
+
+def test_isolation_forest_fit_predict_agreement(blobs_with_outliers):
+    X = blobs_with_outliers
+    params = {"n_estimators": 100, "random_state": 0}
+
+    expected_labels = CPUIsolationForest(**params).fit_predict(X)
+    result = IsolationForest(**params)
+    result_labels = result.fit_predict(X)
+
+    assert result._gpu is not None
+    assert set(np.unique(result_labels)) <= {-1, 1}
+    assert np.mean(expected_labels == result_labels) >= 0.9
+
+
+def test_isolation_forest_fit_predict_rejects_unknown_kwarg(
+    blobs_with_outliers,
+):
+    result = IsolationForest(n_estimators=10, random_state=0)
+
+    with pytest.raises(TypeError, match="unexpected keyword argument 'typo'"):
+        result.fit_predict(blobs_with_outliers, typo=True)
+
+    assert result._gpu is None
 
 
 def test_isolation_forest_fit_sample_weight_falls_back_to_cpu(

--- a/python/cuml/cuml_accel_tests/upstream/scikit-learn/xfail-list.yaml
+++ b/python/cuml/cuml_accel_tests/upstream/scikit-learn/xfail-list.yaml
@@ -38,6 +38,29 @@
   - "sklearn.linear_model.tests.test_coordinate_descent::test_enet_sample_weight_consistency[42-csr_matrix-False-0.01-True-ElasticNet]"
   - "sklearn.linear_model.tests.test_coordinate_descent::test_random_descent[csr_array]"
   - "sklearn.linear_model.tests.test_coordinate_descent::test_random_descent[csr_matrix]"
+- reason: IsolationForest GPU inference is expected to bypass scikit-learn CPU chunking internals
+  marker: cuml_accel_bugs
+  tests:
+  - "sklearn.ensemble.tests.test_iforest::test_iforest_chunks_works1[42-0.25-3]"
+  - "sklearn.ensemble.tests.test_iforest::test_iforest_chunks_works1[42-auto-2]"
+  - "sklearn.ensemble.tests.test_iforest::test_iforest_chunks_works2[42-0.25-3]"
+  - "sklearn.ensemble.tests.test_iforest::test_iforest_chunks_works2[42-auto-2]"
+- reason: IsolationForest estimators_samples_ requires retaining and exporting sampled row indices (#8420)
+  marker: cuml_accel_bugs
+  tests:
+  - "sklearn.tests.test_docstring_parameters::test_fit_docstring_attributes[IsolationForest-IsolationForest]"
+- reason: IsolationForest sample-weight equivalence requires native GPU sample-weight support
+  marker: cuml_accel_bugs
+  tests:
+  - "sklearn.tests.test_common::test_estimators[IsolationForest()-check_sample_weight_equivalence_on_dense_data]"
+  - "sklearn.tests.test_common::test_estimators[IsolationForest()-check_sample_weight_equivalence_on_sparse_data]"
+- reason: IsolationForest sparse/dense equivalence requires native GPU sparse-input support
+  marker: cuml_accel_bugs
+  tests:
+  - "sklearn.ensemble.tests.test_iforest::test_iforest_sparse[42-csc_array]"
+  - "sklearn.ensemble.tests.test_iforest::test_iforest_sparse[42-csc_matrix]"
+  - "sklearn.ensemble.tests.test_iforest::test_iforest_sparse[42-csr_array]"
+  - "sklearn.ensemble.tests.test_iforest::test_iforest_sparse[42-csr_matrix]"
 - reason: LogisticRegression behavior differs with cuml.accel in sklearn 1.9
   marker: cuml_accel_bugs
   condition: scikit-learn>=1.9

--- a/python/cuml/tests/test_isolation_forest.py
+++ b/python/cuml/tests/test_isolation_forest.py
@@ -13,6 +13,7 @@ These tests are designed to be:
 """
 
 import pickle
+import warnings
 
 import cupy as cp
 import numpy as np
@@ -490,6 +491,33 @@ def test_invert_average_path_length_fails_loudly():
     midpoint = float(_average_path_length(np.asarray([50000, 50001])).mean())
     with pytest.raises(ValueError, match="more than one"):
         _invert_average_path_length(midpoint)
+
+
+def test_contamination_float_preserves_feature_names():
+    """Computing the training quantile must retain input feature metadata."""
+    pd = pytest.importorskip("pandas")
+    X = pd.DataFrame(
+        np.random.RandomState(0).normal(size=(20, 2)), columns=["a", "b"]
+    )
+
+    with warnings.catch_warnings():
+        warnings.simplefilter("error", UserWarning)
+        model = cuIsolationForest(
+            n_estimators=5, contamination=0.05, random_state=0
+        ).fit(X)
+
+    np.testing.assert_array_equal(model.feature_names_in_, X.columns)
+
+
+def test_internal_device_scoring_matches_public_path(blobs_data):
+    """The validated and already-converted scoring paths are equivalent."""
+    model = cuIsolationForest(n_estimators=10, random_state=0).fit(blobs_data)
+    X_m = cp.asarray(blobs_data, order="F")
+
+    expected = model.score_samples(blobs_data)
+    actual = model._score_samples(X_m)
+
+    cp.testing.assert_array_equal(cp.asarray(actual), cp.asarray(expected))
 
 
 def test_contamination_float_sets_score_quantile_offset(blobs_data):

--- a/python/cuml/tests/test_isolation_forest.py
+++ b/python/cuml/tests/test_isolation_forest.py
@@ -395,15 +395,30 @@ def test_as_sklearn_float64_parity(anomaly_data):
 def test_as_sklearn_populates_fitted_attributes(blobs_data):
     """The converted model carries the attributes a sklearn fit would set."""
     cu_model = cuIsolationForest(
-        n_estimators=10, max_samples=64, random_state=0
+        n_estimators=10,
+        max_samples=64,
+        max_features=0.5,
+        random_state=0,
     ).fit(blobs_data)
     sk_model = cu_model.as_sklearn()
 
     assert sk_model.max_samples_ == 64
     assert sk_model.offset_ == pytest.approx(float(cu_model.offset_))
     assert sk_model.n_features_in_ == blobs_data.shape[1]
+    assert sk_model.estimator_.max_features == 1
     assert len(sk_model.estimators_) == 10
     assert len(sk_model.estimators_features_) == 10
+    np.testing.assert_array_equal(
+        np.stack(sk_model.estimators_features_), cu_model._feature_indices
+    )
+    for features, tree in zip(
+        sk_model.estimators_features_, sk_model.estimators_, strict=True
+    ):
+        assert features.shape == (2,)
+        assert len(np.unique(features)) == len(features)
+        assert np.all((features >= 0) & (features < blobs_data.shape[1]))
+        split_features = tree.tree_.feature[tree.tree_.feature >= 0]
+        assert np.all(split_features < len(features))
     # The private fit caches sklearn scoring reads must exist and align.
     assert isinstance(sk_model._average_path_length_per_tree, tuple)
     assert isinstance(sk_model._decision_path_lengths, tuple)
@@ -418,6 +433,27 @@ def test_as_sklearn_populates_fitted_attributes(blobs_data):
     # backed by `_seeds` stays unavailable rather than returning wrong ones.
     with pytest.raises(AttributeError):
         sk_model.estimators_samples_
+
+
+def test_feature_indices_survive_native_pickle(blobs_data):
+    """Native pickles retain metadata needed for sklearn conversion."""
+    model = cuIsolationForest(
+        n_estimators=5, max_features=0.5, random_state=0
+    ).fit(blobs_data)
+    restored = pickle.loads(pickle.dumps(model))
+
+    np.testing.assert_array_equal(
+        restored._feature_indices, model._feature_indices
+    )
+    converted = restored.as_sklearn()
+    np.testing.assert_array_equal(
+        np.stack(converted.estimators_features_), model._feature_indices
+    )
+    np.testing.assert_allclose(
+        converted.score_samples(blobs_data),
+        np.asarray(model.score_samples(blobs_data)),
+        atol=1e-5,
+    )
 
 
 def test_as_sklearn_pickle_roundtrip(blobs_data):

--- a/python/cuml/tests/test_isolation_forest.py
+++ b/python/cuml/tests/test_isolation_forest.py
@@ -471,6 +471,24 @@ def test_as_sklearn_pickle_roundtrip(blobs_data):
     )
 
 
+def test_as_sklearn_preserves_strict_split_semantics():
+    X = np.arange(5, dtype=np.float32)[:, None]
+    cu_model = cuIsolationForest(
+        n_estimators=1, max_depth=1, random_state=0
+    ).fit(X)
+    sk_model = cu_model.as_sklearn()
+    threshold = (
+        treelite.sklearn.export_model(cu_model.as_treelite())
+        .estimators_[0]
+        .tree_.threshold[0]
+    )
+    X_equal = np.array([[threshold]], dtype=np.float32)
+
+    np.testing.assert_array_equal(
+        sk_model.predict(X_equal), np.asarray(cu_model.predict(X_equal))
+    )
+
+
 def test_as_sklearn_constant_data():
     """Degenerate single-node trees convert and score identically."""
     X = np.ones((300, 4), dtype=np.float32)

--- a/python/cuml/tests/test_isolation_forest.py
+++ b/python/cuml/tests/test_isolation_forest.py
@@ -509,17 +509,6 @@ def test_contamination_float_preserves_feature_names():
     np.testing.assert_array_equal(model.feature_names_in_, X.columns)
 
 
-def test_internal_device_scoring_matches_public_path(blobs_data):
-    """The validated and already-converted scoring paths are equivalent."""
-    model = cuIsolationForest(n_estimators=10, random_state=0).fit(blobs_data)
-    X_m = cp.asarray(blobs_data, order="F")
-
-    expected = model.score_samples(blobs_data)
-    actual = model._score_samples(X_m)
-
-    cp.testing.assert_array_equal(cp.asarray(actual), cp.asarray(expected))
-
-
 def test_contamination_float_sets_score_quantile_offset(blobs_data):
     """Float contamination should set offset_ from training score quantile."""
     contamination = 0.1


### PR DESCRIPTION
Adds `cuml.accel` support for `sklearn.ensemble.IsolationForest`.

Dense, finite inputs use cuML for `fit`, `fit_predict`, `predict`, `decision_function`, and `score_samples`. Unsupported parameters, sparse inputs, and non-finite inputs fall back to scikit-learn.

Fitted GPU models synchronize to scikit-learn for attribute access, CPU fallback, and pickling. The conversion preserves each tree's sampled feature subset and remaps exported split indices to scikit-learn's subset-local representation. `estimators_samples_` remains unavailable because cuML does not retain per-tree row samples.

Adds integration coverage for GPU dispatch, CPU fallback, prediction agreement, fitted-state synchronization, and pickle round trips, along with focused native and upstream scikit-learn coverage.

Closes #8468
