### PR TITLE
Support dataframe-like inputs in reflection machinery

### DIFF
--- a/python/cuml/cuml/internals/outputs.py
+++ b/python/cuml/cuml/internals/outputs.py
@@ -447,13 +447,12 @@ def convert_arrays(
     Parameters
     ----------
     obj : object
-        The object to convert. Any cupy arrays, numpy arrays, cupyx sparse
-        matrices, scipy sparse matrices, or cuml-specific output types
-        (`ClassLabels`, `ArrayIndexPair`) will be converted to the specified
-        `output_type`. Some builtin collections (dict, list, tuple) are
-        traversed recursively to find array-likes. Other array-likes (pandas,
-        ...) will error as unsupported. Any other type is passed through
-        unchanged.
+        The object to convert. Any cupy arrays, numpy arrays, cudf
+        Series/DataFrame, pandas Series/DataFrames, cupyx sparse matrices,
+        scipy sparse matrices, or cuml-specific output types (`ClassLabels`,
+        `ArrayIndexPair`) will be converted to the specified `output_type`.
+        Some builtin collections (dict, list, tuple) are traversed recursively
+        to find array-likes. Any other type is passed through unchanged.
     output_type : {'cupy', 'numpy', 'cudf', 'pandas'}
         The output type to convert to.
     index : pandas.Index, cudf.Index, or None, default=None
@@ -476,6 +475,40 @@ def convert_arrays(
 
     if isinstance(obj, ClassLabels):
         return obj.to_output(output_type, index=index)
+
+    if isinstance(obj, (cudf.Series, cudf.DataFrame, pd.Series, pd.DataFrame)):
+        is_pandas = isinstance(obj, (pd.Series, pd.DataFrame))
+        if output_type == "numpy":
+            return obj.to_numpy()
+        elif output_type in ("cudf", "pandas"):
+            if index is not None:
+                if is_pandas and hasattr(index, "to_pandas"):
+                    index = index.to_pandas()
+                obj = obj.copy(deep=False)
+                obj.index = index
+            if is_pandas:
+                return (
+                    obj if output_type == "pandas" else cudf.from_pandas(obj)
+                )
+            else:
+                if output_type == "cudf":
+                    return obj
+                return (
+                    cudf.pandas.as_proxy_object(obj)
+                    if cudf.pandas.LOADED
+                    else obj.to_pandas()
+                )
+        else:
+            assert output_type in ("cuml", "cupy")
+            if not (
+                obj.dtype.kind in "iufb"
+                if isinstance(obj, (pd.Series, cudf.Series))
+                else all(dt.kind in "iufb" for dt in obj.dtypes)
+            ):
+                raise TypeError(
+                    f"{output_type=!r} doesn't support non-numeric dtypes"
+                )
+            return cp.asarray(obj.to_numpy()) if is_pandas else obj.to_cupy()
 
     if isinstance(obj, np.ndarray):
         if output_type == "numpy":
@@ -530,17 +563,6 @@ def convert_arrays(
         else:
             # Use coo for coo and all other formats
             return cp_sp.coo_matrix(obj)
-
-    elif isinstance(
-        obj, (cudf.Series, cudf.DataFrame, pd.Series, pd.DataFrame)
-    ):
-        raise TypeError(
-            f"Cannot return objects of type {type(obj).__name__} directly "
-            f"from an `mlfunc`-decorated function. Please return a "
-            f"`cupy.ndarray`, `numpy.ndarray`, `cupyx.scipy.sparse.spmatrix`, "
-            f"`scipy.sparse.spmatrix`, `ArrayIndexPair`, "
-            f"or `ClassLabels` instead."
-        )
 
     elif isinstance(obj, list):
         return [

--- a/python/cuml/tests/test_reflection.py
+++ b/python/cuml/tests/test_reflection.py
@@ -53,10 +53,11 @@ def rand_array(output_type, *, shape=(8, 4), seed=42):
     elif output_type == "numpy":
         return cp.asnumpy(X)
     elif output_type == "pandas":
-        return pd.DataFrame(X.get())
+        X = X.get()
+        return pd.DataFrame(X) if X.ndim == 2 else pd.Series(X)
     else:
         assert output_type == "cudf"
-        return cudf.DataFrame(X)
+        return cudf.DataFrame(X) if X.ndim == 2 else cudf.Series(X)
 
 
 class ImplementsArray:
@@ -284,19 +285,42 @@ def test_global_input_with_estimator_output_type():
     assert_output_type(model.components_, "pandas")
 
 
-@pytest.mark.parametrize("input_type", ["numpy", "cupy"])
+@pytest.mark.parametrize(
+    "input_type, order",
+    [
+        ("numpy", "C"),
+        ("numpy", "F"),
+        ("cupy", "C"),
+        ("cupy", "F"),
+        ("pandas", "F"),
+        ("cudf", "F"),
+    ],
+)
 @pytest.mark.parametrize("output_type", ["numpy", "cupy"])
-@pytest.mark.parametrize("order", ["C", "F"])
-def test_convert_arrays_dense_array(input_type, output_type, order):
+def test_convert_arrays_dense_array(input_type, order, output_type):
+    X = rand_array(input_type)
     if input_type == "cupy":
-        X = cp.asarray(rand_array("cupy"), order=order)
-    else:
-        X = np.asarray(rand_array("numpy"), order=order)
+        X = cp.asarray(X, order=order)
+    elif input_type == "numpy":
+        X = np.asarray(X, order=order)
 
     out = convert_arrays(X, output_type)
+    sol = X.to_numpy() if hasattr(X, "to_numpy") else cp.asnumpy(X)
+
     assert_output_type(out, output_type)
-    np.testing.assert_array_equal(cp.asnumpy(X), cp.asnumpy(out))
+    np.testing.assert_array_equal(cp.asnumpy(out), sol)
     assert out.flags.c_contiguous if order == "C" else out.flags.f_contiguous
+
+
+@pytest.mark.parametrize("input_type", ["numpy", "cupy", "pandas", "cudf"])
+@pytest.mark.parametrize("output_type", ["numpy", "cupy"])
+def test_convert_arrays_dense_array_1d(input_type, output_type):
+    X = rand_array(input_type, shape=8)
+    out = convert_arrays(X, output_type)
+    sol = X.to_numpy() if hasattr(X, "to_numpy") else cp.asnumpy(X)
+
+    assert_output_type(out, output_type)
+    np.testing.assert_array_equal(cp.asnumpy(out), sol)
 
 
 @pytest.mark.parametrize("input_type", ["scipy", "cupyx"])
@@ -328,7 +352,7 @@ def test_convert_arrays_sparse_array(input_type, output_type, format):
 
 
 @pytest.mark.parametrize("kind", ["dataframe", "series"])
-@pytest.mark.parametrize("input_type", ["cupy", "numpy"])
+@pytest.mark.parametrize("input_type", ["cupy", "numpy", "pandas", "cudf"])
 @pytest.mark.parametrize("output_type", ["pandas", "cudf"])
 def test_convert_arrays_dataframe(kind, input_type, output_type):
     arr = rand_array(input_type, shape=((8, 4) if kind == "dataframe" else 8))
@@ -346,7 +370,7 @@ def test_convert_arrays_dataframe(kind, input_type, output_type):
 @pytest.mark.parametrize("xdf", [pd, cudf])
 @pytest.mark.parametrize("kind", ["dataframe", "series"])
 @pytest.mark.parametrize("use_pair", [False, True])
-@pytest.mark.parametrize("input_type", ["cupy", "numpy"])
+@pytest.mark.parametrize("input_type", ["cupy", "numpy", "pandas", "cudf"])
 @pytest.mark.parametrize("output_type", ["pandas", "cudf"])
 def test_convert_arrays_dataframe_with_index(
     xdf, kind, use_pair, input_type, output_type
@@ -360,13 +384,13 @@ def test_convert_arrays_dataframe_with_index(
         res = convert_arrays(arr, output_type, index=index)
 
     if kind == "dataframe":
-        cudf.testing.assert_frame_equal(
-            cudf.DataFrame(res), cudf.DataFrame(arr, index=index)
-        )
+        sol = cudf.DataFrame(arr)
+        sol.index = index
+        cudf.testing.assert_frame_equal(cudf.DataFrame(res), sol)
     else:
-        cudf.testing.assert_series_equal(
-            cudf.Series(res), cudf.Series(arr, index=index)
-        )
+        sol = cudf.Series(arr)
+        sol.index = index
+        cudf.testing.assert_series_equal(cudf.Series(res), sol)
 
 
 @pytest.mark.parametrize(


### PR DESCRIPTION
Previously our reflection machinery (specifically `convert_arrays`) didn't support coercing dataframe-like inputs to other array types. This was to keep things simple, since all existing code paths returned cupy or numpy arrays.

I now have a use case for returning a `cudf.DataFrame` from a method (and having it automatically coerced to the selected `output_type`). For completeness I've implemented support for all dataframe-like inputs as well, rounding out the implementation. We now have full N->N mapping in `convert_arrays` for coercing all natively supported input types to all natively supported output types.