### PR TITLE
Add RAFT option to make_blobs

### DIFF
--- a/python/cuml/cuml/datasets/CMakeLists.txt
+++ b/python/cuml/cuml/datasets/CMakeLists.txt
@@ -1,12 +1,13 @@
 # =============================================================================
 # cmake-format: off
-# SPDX-FileCopyrightText: Copyright (c) 2022-2025, NVIDIA CORPORATION.
+# SPDX-FileCopyrightText: Copyright (c) 2022-2026, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
 # SPDX-License-Identifier: Apache-2.0
 # cmake-format: on
 # =============================================================================
 
 set(cython_sources "")
 add_module_gpu_default("arima.pyx" ${arima_algo} ${datasets_algo})
+add_module_gpu_default("_blobs.pyx" ${datasets_algo})
 add_module_gpu_default("regression.pyx" ${regression_algo} ${datasets_algo})
 
 rapids_cython_create_modules(

--- a/python/cuml/cuml/datasets/_blobs.pyx
+++ b/python/cuml/cuml/datasets/_blobs.pyx
@@ -1,0 +1,124 @@
+#
+# SPDX-FileCopyrightText: Copyright (c) 2026, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+#
+
+import cupy as cp
+
+from cuml.internals import get_handle
+
+from libc.stddef cimport size_t
+from libc.stdint cimport int64_t, uint64_t, uintptr_t
+from libcpp cimport bool
+from pylibraft.common.handle cimport handle_t
+
+
+cdef extern from "cuml/datasets/make_blobs.hpp" namespace "ML" nogil:
+    void cpp_make_blobs "ML::Datasets::make_blobs" (
+        const handle_t& handle,
+        float* out,
+        int64_t* labels,
+        int64_t n_rows,
+        int64_t n_cols,
+        int64_t n_clusters,
+        bool row_major,
+        const float* centers,
+        const float* cluster_std,
+        const float cluster_std_scalar,
+        bool shuffle,
+        float center_box_min,
+        float center_box_max,
+        uint64_t seed) except +
+
+    void cpp_make_blobs "ML::Datasets::make_blobs" (
+        const handle_t& handle,
+        double* out,
+        int64_t* labels,
+        int64_t n_rows,
+        int64_t n_cols,
+        int64_t n_clusters,
+        bool row_major,
+        const double* centers,
+        const double* cluster_std,
+        const double cluster_std_scalar,
+        bool shuffle,
+        double center_box_min,
+        double center_box_max,
+        uint64_t seed) except +
+
+
+# - Grabs cuML's current RAFT handle for the native call.
+# - Allocates X plus a small integer label buffer on the GPU.
+# - Passes the CuPy pointers into the existing C++ make_blobs function.
+# - Picks the float or double overload from the requested dtype.
+# - Syncs once, then casts labels back to the Python API dtype.
+def make_blobs(
+    n_samples,
+    n_features,
+    n_centers,
+    centers,
+    cluster_std,
+    center_box_min,
+    center_box_max,
+    shuffle,
+    random_state,
+    order,
+    dtype,
+):
+    dtype = cp.dtype(dtype)
+
+    h = get_handle()
+    cdef handle_t* h_ptr = <handle_t*><size_t>h.getHandle()
+
+    X = cp.empty((n_samples, n_features), dtype=dtype, order=order)
+    y = cp.empty(n_samples, dtype=cp.int64)
+
+    cdef uintptr_t x_p = X.data.ptr
+    cdef uintptr_t y_p = y.data.ptr
+    cdef uintptr_t ctr_p = 0
+    if centers is not None:
+        ctr_p = centers.data.ptr
+
+    cdef bool row_c = order == "C"
+
+    if dtype == cp.dtype("float32"):
+        cpp_make_blobs(
+            h_ptr[0],
+            <float*>x_p,
+            <int64_t*>y_p,
+            <int64_t>n_samples,
+            <int64_t>n_features,
+            <int64_t>n_centers,
+            row_c,
+            <const float*>ctr_p,
+            <const float*>0,
+            <float>cluster_std,
+            <bool>shuffle,
+            <float>center_box_min,
+            <float>center_box_max,
+            <uint64_t>random_state,
+        )
+    elif dtype == cp.dtype("float64"):
+        cpp_make_blobs(
+            h_ptr[0],
+            <double*>x_p,
+            <int64_t*>y_p,
+            <int64_t>n_samples,
+            <int64_t>n_features,
+            <int64_t>n_centers,
+            row_c,
+            <const double*>ctr_p,
+            <const double*>0,
+            <double>cluster_std,
+            <bool>shuffle,
+            <double>center_box_min,
+            <double>center_box_max,
+            <uint64_t>random_state,
+        )
+    else:
+        raise ValueError("RAFT make_blobs only supports float32 and float64.")
+
+    # Native labels are integers; Python make_blobs has historically returned
+    # them in the requested floating dtype, so keep that behavior here.
+    h.sync()
+    return X, y.astype(dtype, copy=False)

--- a/python/cuml/cuml/datasets/blobs.py
+++ b/python/cuml/cuml/datasets/blobs.py
@@ -5,6 +5,7 @@
 
 import numbers
 from collections.abc import Iterable
+from random import getrandbits
 
 import cupy as cp
 import numpy as np
@@ -14,6 +15,11 @@ import cuml.internals.nvtx as nvtx
 from cuml.datasets.utils import _create_rs_generator
 
 
+# - Figures out how many centers this call needs.
+# - Makes random centers when none were handed in.
+# - Checks that sample counts and center shapes line up.
+# - Leaves fixed centers alone when they already fit.
+# - Hands back the centers plus their count.
 def _get_centers(rs, centers, center_box, n_samples, n_features, dtype):
     if isinstance(n_samples, numbers.Integral):
         # Set n_centers by looking at centers arg
@@ -70,6 +76,148 @@ def _get_centers(rs, centers, center_box, n_samples, n_features, dtype):
     return centers, n_centers
 
 
+# - Checks the smaller set of inputs RAFT can handle here.
+# - Sorts out generated centers versus centers the caller passed in.
+# - Keeps center memory order lined up with the output array.
+# - Turns random_state into the uint64 seed RAFT expects.
+# - Calls the Cython bridge and gives the same Python-style result back.
+def _make_blobs_raft(
+    n_samples,
+    n_features,
+    centers,
+    cluster_std,
+    center_box,
+    shuffle,
+    random_state,
+    return_centers,
+    order,
+    dtype,
+):
+    if not isinstance(n_samples, numbers.Integral):
+        raise ValueError(
+            "`n_samples` must be an integer when `use_raft=True`."
+        )
+    if not isinstance(n_features, numbers.Integral):
+        raise ValueError(
+            "`n_features` must be an integer when `use_raft=True`."
+        )
+
+    n_samples, n_features = int(n_samples), int(n_features)
+    if n_samples <= 0:
+        raise ValueError("`n_samples` must be greater than 0.")
+    if n_features <= 0:
+        raise ValueError("`n_features` must be greater than 0.")
+
+    if not isinstance(cluster_std, numbers.Real):
+        raise ValueError(
+            "`cluster_std` must be a scalar when `use_raft=True`."
+        )
+    if cluster_std < 0:
+        raise ValueError("`cluster_std` must be non-negative.")
+
+    dtype = cp.dtype(dtype)
+    if dtype not in (cp.dtype("float32"), cp.dtype("float64")):
+        raise ValueError(
+            "RAFT make_blobs only supports float32 and float64 output."
+        )
+    if order not in ("C", "F"):
+        raise ValueError("`order` must be either 'C' or 'F'.")
+
+    made_ctr = False
+    if centers is None:
+        n_ctr, r_ctr, made_ctr = 3, None, True
+    elif isinstance(centers, numbers.Integral):
+        n_ctr, r_ctr, made_ctr = int(centers), None, True
+        if n_ctr <= 0:
+            raise ValueError("`centers` must be greater than 0.")
+    else:
+        r_ctr = cp.asarray(centers, dtype=dtype, order=order)
+        if r_ctr.ndim != 2:
+            raise ValueError(
+                "`centers` must be a 2D array when `use_raft=True`."
+            )
+        if r_ctr.shape[1] != n_features:
+            raise ValueError(
+                "Expected `n_features` to be equal to"
+                " the length of axis 1 of centers array"
+            )
+
+        n_ctr = int(r_ctr.shape[0])
+        if n_ctr <= 0:
+            raise ValueError("`centers` must contain at least one center.")
+
+        # RAFT uses the same layout flag for X and centers, so keep them paired.
+        # cp.asarray can keep an input layout in a few CUDA-array cases.
+        if order == "C" and not r_ctr.flags["C_CONTIGUOUS"]:
+            r_ctr = cp.ascontiguousarray(r_ctr)
+        elif order == "F" and not r_ctr.flags["F_CONTIGUOUS"]:
+            r_ctr = cp.asfortranarray(r_ctr)
+
+    if made_ctr:
+        try:
+            box_lo, box_hi = center_box
+        except (TypeError, ValueError):
+            raise ValueError("`center_box` must contain exactly two values.")
+
+        if not isinstance(box_lo, numbers.Real) or not isinstance(
+            box_hi, numbers.Real
+        ):
+            raise ValueError("`center_box` values must be real numbers.")
+        if box_lo > box_hi:
+            raise ValueError(
+                "`center_box` minimum must not exceed its maximum."
+            )
+    else:
+        # The native call ignores the box once actual center locations are given.
+        box_lo = box_hi = 0.0
+
+    if return_centers and made_ctr:
+        raise ValueError(
+            "`return_centers=True` with generated centers is not supported "
+            "when `use_raft=True`; pass explicit center locations instead."
+        )
+
+    if random_state is None:
+        seed = getrandbits(64)
+    elif isinstance(random_state, numbers.Integral):
+        seed = int(random_state)
+        if not 0 <= seed <= (1 << 64) - 1:
+            raise ValueError(
+                "`random_state` must be between 0 and 2**64 - 1 "
+                "when `use_raft=True`."
+            )
+    else:
+        raise ValueError(
+            "`random_state` must be an integer or None when `use_raft=True`."
+        )
+
+    # Keep this import here so the normal CuPy path does not need the native module.
+    from cuml.datasets._blobs import make_blobs as raft_blobs
+
+    X, y = raft_blobs(
+        n_samples=n_samples,
+        n_features=n_features,
+        n_centers=n_ctr,
+        centers=r_ctr,
+        cluster_std=float(cluster_std),
+        center_box_min=float(box_lo),
+        center_box_max=float(box_hi),
+        shuffle=bool(shuffle),
+        random_state=seed,
+        order=order,
+        dtype=dtype,
+    )
+
+    if return_centers:
+        return X, y, r_ctr
+    return X, y
+
+
+# - Keeps the existing CuPy generator as the default path.
+# - Sends the call to RAFT only when use_raft=True.
+# - Uses the same public arguments either way.
+# - Keeps the current return shape and label dtype behavior.
+# - Falls straight back into the original generator code otherwise.
 @nvtx.annotate(message="datasets.make_blobs", domain="cuml_python")
 @cuml.internals.mlfunc(array_arg=None)
 def make_blobs(
@@ -83,6 +231,7 @@ def make_blobs(
     return_centers=False,
     order="F",
     dtype="float32",
+    use_raft=False,
 ):
     """Generate isotropic Gaussian blobs for clustering.
 
@@ -117,6 +266,11 @@ def make_blobs(
         The order of the generated samples
     dtype : str, optional (default='float32')
         Dtype of the generated samples
+    use_raft : bool, optional (default=False)
+        If True, send generation through RAFT's C++ ``make_blobs`` path.
+        False keeps the existing CuPy path. RAFT currently expects integer
+        ``n_samples``, scalar ``cluster_std``, and an integer or None
+        ``random_state``; generated centers cannot be returned.
 
     Returns
     -------
@@ -151,6 +305,20 @@ def make_blobs(
     --------
     make_classification: a more intricate variant
     """
+    if use_raft:
+        return _make_blobs_raft(
+            n_samples=n_samples,
+            n_features=n_features,
+            centers=centers,
+            cluster_std=cluster_std,
+            center_box=center_box,
+            shuffle=shuffle,
+            random_state=random_state,
+            return_centers=return_centers,
+            order=order,
+            dtype=dtype,
+        )
+
     generator = _create_rs_generator(random_state=random_state)
 
     centers, n_centers = _get_centers(

--- a/python/cuml/tests/test_make_blobs.py
+++ b/python/cuml/tests/test_make_blobs.py
@@ -1,4 +1,5 @@
-# SPDX-FileCopyrightText: Copyright (c) 2019-2025, NVIDIA CORPORATION.
+#
+# SPDX-FileCopyrightText: Copyright (c) 2019-2026, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
 # SPDX-License-Identifier: Apache-2.0
 #
 
@@ -34,6 +35,11 @@ shuffle = [True, False]
 random_state = [None, 9]
 
 
+# - Runs the existing CuPy path across its scalar parameter combinations.
+# - Checks the output and label shapes.
+# - Checks both C and F output layouts.
+# - Checks the expected number of clusters.
+# - Keeps the original make_blobs coverage in place.
 @pytest.mark.parametrize("dtype", dtype)
 @pytest.mark.parametrize("n_samples", n_samples)
 @pytest.mark.parametrize("n_features", n_features)
@@ -80,3 +86,153 @@ def test_make_blobs_scalar_parameters(
         assert cp.unique(labels).shape == (centers,), (
             "unexpected number of clusters"
         )
+
+
+# - Checks that leaving RAFT off still means the old CuPy path.
+# - Uses a fixed seed so both calls should line up exactly.
+# - Compares the samples instead of just checking their shapes.
+# - Compares the labels too.
+# - Keeps this as a small compatibility check.
+def test_make_blobs_raft_disabled_matches_default():
+    kw = {
+        "n_samples": 64,
+        "n_features": 3,
+        "centers": 4,
+        "cluster_std": 0.2,
+        "random_state": 17,
+    }
+
+    out_a, labels_a = cuml.make_blobs(**kw)
+    out_b, labels_b = cuml.make_blobs(**kw, use_raft=False)
+
+    cp.testing.assert_array_equal(out_a, out_b)
+    cp.testing.assert_array_equal(labels_a, labels_b)
+
+
+# - Runs the RAFT path twice with the same seed.
+# - Covers both supported floating dtypes.
+# - Covers both C and F output layouts.
+# - Checks the existing floating label dtype stays the same.
+# - Makes sure the requested four clusters are present.
+@pytest.mark.parametrize("dtype", ["float32", "float64"])
+@pytest.mark.parametrize("order", ["F", "C"])
+def test_make_blobs_raft_reproducible(dtype, order):
+    kw = {
+        "n_samples": 128,
+        "n_features": 4,
+        "centers": 4,
+        "cluster_std": 0.3,
+        "random_state": 1234,
+        "order": order,
+        "dtype": dtype,
+        "use_raft": True,
+    }
+
+    out_a, labels_a = cuml.make_blobs(**kw)
+    out_b, labels_b = cuml.make_blobs(**kw)
+
+    cp.testing.assert_array_equal(out_a, out_b)
+    cp.testing.assert_array_equal(labels_a, labels_b)
+
+    assert out_a.dtype == cp.dtype(dtype)
+    assert labels_a.dtype == cp.dtype(dtype)
+    assert out_a.flags[f"{order}_CONTIGUOUS"]
+    assert cp.unique(labels_a).shape == (4,)
+
+
+# - Calls the public RAFT option and the private native bridge.
+# - Gives both calls the exact same inputs.
+# - Checks that the Python wrapper forwards the seed correctly.
+# - Checks that generated samples match exactly.
+# - Checks that the labels match exactly too.
+def test_make_blobs_raft_matches_native_bridge():
+    from cuml.datasets._blobs import make_blobs as raft_blobs
+
+    out_a, labels_a = cuml.make_blobs(
+        n_samples=96,
+        n_features=3,
+        centers=3,
+        cluster_std=0.25,
+        center_box=(-2.0, 5.0),
+        random_state=2026,
+        order="C",
+        dtype="float32",
+        use_raft=True,
+    )
+
+    out_b, labels_b = raft_blobs(
+        n_samples=96,
+        n_features=3,
+        n_centers=3,
+        centers=None,
+        cluster_std=0.25,
+        center_box_min=-2.0,
+        center_box_max=5.0,
+        shuffle=True,
+        random_state=2026,
+        order="C",
+        dtype=cp.dtype("float32"),
+    )
+
+    cp.testing.assert_array_equal(out_a, out_b)
+    cp.testing.assert_array_equal(labels_a, labels_b)
+
+
+# - Passes fixed centers instead of asking RAFT to make them.
+# - Checks both output layouts with the same center values.
+# - Asks for the centers back through the public API.
+# - Makes sure those returned centers are unchanged.
+# - Confirms both clusters show up in the labels.
+@pytest.mark.parametrize("order", ["F", "C"])
+def test_make_blobs_raft_explicit_centers(order):
+    fixed = cp.asarray(
+        [[-2.0, -2.0], [2.0, 2.0]],
+        dtype=cp.float32,
+        order="C",
+    )
+
+    out, labels, got = cuml.make_blobs(
+        n_samples=96,
+        n_features=2,
+        centers=fixed,
+        cluster_std=0.1,
+        random_state=7,
+        return_centers=True,
+        order=order,
+        dtype="float32",
+        use_raft=True,
+    )
+
+    cp.testing.assert_array_equal(got, fixed)
+    assert out.flags[f"{order}_CONTIGUOUS"]
+    assert got.flags[f"{order}_CONTIGUOUS"]
+    assert cp.unique(labels).shape == (2,)
+
+
+# - Keeps the RAFT-only input limits covered in one small test.
+# - Checks list sample counts are rejected.
+# - Checks per-center standard deviations are rejected.
+# - Checks unsupported order and dtype values are rejected.
+# - Checks generated centers cannot be returned yet.
+@pytest.mark.parametrize(
+    ("extra", "msg"),
+    [
+        ({"n_samples": [10, 10]}, "n_samples"),
+        ({"cluster_std": [0.1, 0.2]}, "cluster_std"),
+        ({"order": "A"}, "order"),
+        ({"dtype": "float16"}, "float32 and float64"),
+        ({"return_centers": True}, "return_centers"),
+    ],
+)
+def test_make_blobs_raft_rejects_unsupported_inputs(extra, msg):
+    kw = {
+        "n_samples": 32,
+        "n_features": 2,
+        "centers": 2,
+        "random_state": 3,
+        "use_raft": True,
+    }
+    kw.update(extra)
+
+    with pytest.raises(ValueError, match=msg):
+        cuml.make_blobs(**kw)


### PR DESCRIPTION
Adds an opt-in RAFT path to `cuml.datasets.make_blobs`.

The existing CuPy path stays the default.

Added focused tests for seeded reproducibility and C/F layouts.

Fixes #7363.