### PR TITLE
Fix devcontainer cache version updates

### DIFF
--- a/.devcontainer/cuda12.9-conda/devcontainer.json
+++ b/.devcontainer/cuda12.9-conda/devcontainer.json
@@ -8,7 +8,7 @@
       "BASE": "rapidsai/devcontainers:26.10-cpp-mambaforge"
     },
     "cacheFrom": [
-      "ghcr.io/rapidsai/cuml/devcontainer:26.08-cuda12.9-conda"
+      "ghcr.io/rapidsai/cuml/devcontainer:26.10-cuda12.9-conda"
     ]
   },
   "runArgs": [

--- a/.devcontainer/cuda12.9-pip/devcontainer.json
+++ b/.devcontainer/cuda12.9-pip/devcontainer.json
@@ -8,7 +8,7 @@
       "BASE": "rapidsai/devcontainers:26.10-cpp-cuda12.9-ucx1.19.0-openmpi5.0.10"
     },
     "cacheFrom": [
-      "ghcr.io/rapidsai/cuml/devcontainer:26.08-cuda12.9-pip"
+      "ghcr.io/rapidsai/cuml/devcontainer:26.10-cuda12.9-pip"
     ]
   },
   "runArgs": [

--- a/.devcontainer/cuda13.3-conda/devcontainer.json
+++ b/.devcontainer/cuda13.3-conda/devcontainer.json
@@ -8,7 +8,7 @@
       "BASE": "rapidsai/devcontainers:26.10-cpp-mambaforge"
     },
     "cacheFrom": [
-      "ghcr.io/rapidsai/cuml/devcontainer:26.08-cuda13.3-conda"
+      "ghcr.io/rapidsai/cuml/devcontainer:26.10-cuda13.3-conda"
     ]
   },
   "runArgs": [

--- a/.devcontainer/cuda13.3-pip/devcontainer.json
+++ b/.devcontainer/cuda13.3-pip/devcontainer.json
@@ -8,7 +8,7 @@
       "BASE": "rapidsai/devcontainers:26.10-cpp-cuda13.3-ucx1.19.0-openmpi5.0.10"
     },
     "cacheFrom": [
-      "ghcr.io/rapidsai/cuml/devcontainer:26.08-cuda13.3-pip"
+      "ghcr.io/rapidsai/cuml/devcontainer:26.10-cuda13.3-pip"
     ]
   },
   "runArgs": [

--- a/ci/release/update-version.sh
+++ b/ci/release/update-version.sh
@@ -144,6 +144,7 @@ done
 # .devcontainer files
 find .devcontainer/ -type f -name devcontainer.json -print0 | while IFS= read -r -d '' filename; do
     sed_runner "s@rapidsai/devcontainers:[0-9.]*@rapidsai/devcontainers:${NEXT_SHORT_TAG}@g" "${filename}"
+    sed_runner "s@ghcr.io/rapidsai/cuml/devcontainer:[0-9.]*@ghcr.io/rapidsai/cuml/devcontainer:${NEXT_SHORT_TAG}@g" "${filename}"
     sed_runner "s@rapidsai/devcontainers/features/ucx:[0-9.]*@rapidsai/devcontainers/features/ucx:${NEXT_SHORT_TAG_PEP440}@" "${filename}"
     sed_runner "s@rapidsai/devcontainers/features/cuda:[0-9.]*@rapidsai/devcontainers/features/cuda:${NEXT_SHORT_TAG_PEP440}@" "${filename}"
     sed_runner "s@rapidsai/devcontainers/features/rapids-build-utils:[0-9.]*@rapidsai/devcontainers/features/rapids-build-utils:${NEXT_SHORT_TAG_PEP440}@" "${filename}"


### PR DESCRIPTION
Update devcontainer cache image tags missed by the 26.10 version bump.

Teach the version update script to update these tags in future releases.

xref: rapidsai/build-planning#316
