### PR TITLE
FIX Remove spurious `IsolationForest` arguments

### DIFF
--- a/python/cuml/cuml/ensemble/isolation_forest.pyx
+++ b/python/cuml/cuml/ensemble/isolation_forest.pyx
@@ -422,8 +422,6 @@ class IsolationForest(InteropMixin, CMajorInputTagMixin, Base):
         - If ``"auto"``, the offset is set to -0.5.
         - If float, must be in the range (0, 0.5] and the offset is set to
           the corresponding training-score quantile.
-    warm_start : bool, default=False
-        ``warm_start=True`` is not currently supported.
     verbose : int or boolean, default=False
         Sets logging level. It must be one of `cuml.common.logger.level_*`.
         See :ref:`verbosity-levels` for more info.
@@ -478,7 +476,6 @@ class IsolationForest(InteropMixin, CMajorInputTagMixin, Base):
         bootstrap=False,
         random_state=None,
         contamination="auto",
-        warm_start=False,
         verbose=False,
         output_type=None,
     ):
@@ -498,7 +495,6 @@ class IsolationForest(InteropMixin, CMajorInputTagMixin, Base):
         self.bootstrap = bootstrap
         self.random_state = random_state
         self.contamination = contamination
-        self.warm_start = warm_start
 
     @classmethod
     def _get_param_names(cls):
@@ -511,7 +507,6 @@ class IsolationForest(InteropMixin, CMajorInputTagMixin, Base):
             "bootstrap",
             "random_state",
             "contamination",
-            "warm_start",
         ]
 
     @classmethod
@@ -527,7 +522,6 @@ class IsolationForest(InteropMixin, CMajorInputTagMixin, Base):
             "bootstrap": model.bootstrap,
             "random_state": model.random_state,
             "contamination": model.contamination,
-            "warm_start": model.warm_start,
         }
 
     def _params_to_cpu(self):
@@ -539,7 +533,6 @@ class IsolationForest(InteropMixin, CMajorInputTagMixin, Base):
             "bootstrap": self.bootstrap,
             "random_state": self.random_state,
             "contamination": self.contamination,
-            "warm_start": self.warm_start,
         }
 
     def _attrs_from_cpu(self, model):
@@ -569,7 +562,7 @@ class IsolationForest(InteropMixin, CMajorInputTagMixin, Base):
         self.__dict__.update(state)
 
     @mlfunc(set_input_type=True)
-    def fit(self, X, y=None, sample_weight=None):
+    def fit(self, X, y=None):
         """
         Fit the Isolation Forest model.
 
@@ -580,19 +573,12 @@ class IsolationForest(InteropMixin, CMajorInputTagMixin, Base):
             or float64.
         y : Ignored
             Not used, present for API consistency.
-        sample_weight : array-like of shape (n_samples,), default=None
-            Not currently supported.
 
         Returns
         -------
         self : IsolationForest
             Fitted estimator.
         """
-        if self.warm_start:
-            raise UnsupportedOnGPU("`warm_start=True` is not supported")
-        if sample_weight is not None:
-            raise UnsupportedOnGPU("`sample_weight` is not supported")
-
         # Release any existing native model.
         self._model = None
 
@@ -1048,7 +1034,7 @@ class IsolationForest(InteropMixin, CMajorInputTagMixin, Base):
         return -predictions
 
     @mlfunc(preserve_index=True)
-    def fit_predict(self, X, y=None, sample_weight=None):
+    def fit_predict(self, X, y=None):
         """
         Fit the model and predict on X.
 
@@ -1058,12 +1044,10 @@ class IsolationForest(InteropMixin, CMajorInputTagMixin, Base):
             The input samples.
         y : Ignored
             Not used, present for API consistency.
-        sample_weight : array-like of shape (n_samples,), default=None
-            Not currently supported.
 
         Returns
         -------
         labels : ndarray of shape (n_samples,)
             1 for inliers, -1 for outliers.
         """
-        return self.fit(X, sample_weight=sample_weight).predict(X)
+        return self.fit(X).predict(X)

--- a/python/cuml/tests/test_isolation_forest.py
+++ b/python/cuml/tests/test_isolation_forest.py
@@ -285,12 +285,6 @@ def test_bootstrap_parameter(blobs_data, bootstrap):
     assert predictions.shape[0] == blobs_data.shape[0]
 
 
-def test_unsupported_warm_start():
-    """sklearn models with warm_start=True cannot be converted."""
-    with pytest.raises(UnsupportedOnGPU, match="warm_start"):
-        cuIsolationForest.from_sklearn(skIsolationForest(warm_start=True))
-
-
 def test_unfitted_sklearn_conversion_preserves_parameters():
     """Unfitted estimators may still be converted in either direction."""
     cu_model = cuIsolationForest(n_estimators=7, random_state=42)

--- a/python/cuml/tests/test_isolation_forest.py
+++ b/python/cuml/tests/test_isolation_forest.py
@@ -285,20 +285,10 @@ def test_bootstrap_parameter(blobs_data, bootstrap):
     assert predictions.shape[0] == blobs_data.shape[0]
 
 
-def test_unsupported_sample_weight(blobs_data):
-    """sample_weight should fail explicitly until backend support is added."""
-    clf = cuIsolationForest(n_estimators=10, random_state=42)
-
-    with pytest.raises(UnsupportedOnGPU, match="sample_weight"):
-        clf.fit(blobs_data, sample_weight=np.ones(blobs_data.shape[0]))
-
-
-def test_unsupported_warm_start(blobs_data):
-    """warm_start=True should fail explicitly."""
-    clf = cuIsolationForest(n_estimators=10, random_state=42, warm_start=True)
-
+def test_unsupported_warm_start():
+    """sklearn models with warm_start=True cannot be converted."""
     with pytest.raises(UnsupportedOnGPU, match="warm_start"):
-        clf.fit(blobs_data)
+        cuIsolationForest.from_sklearn(skIsolationForest(warm_start=True))
 
 
 def test_unfitted_sklearn_conversion_preserves_parameters():

--- a/python/cuml/tests/test_sklearn_compatibility.py
+++ b/python/cuml/tests/test_sklearn_compatibility.py
@@ -190,15 +190,6 @@ XFAILS = {
         "check_estimators_unfitted": (
             "Unfitted methods raise RuntimeError instead of NotFittedError"
         ),
-        "check_sample_weights_pandas_series": "Sample weights are not supported",
-        "check_sample_weights_not_an_array": "Sample weights are not supported",
-        "check_sample_weights_list": "Sample weights are not supported",
-        "check_all_zero_sample_weights_error": "Sample weights are not supported",
-        "check_sample_weights_shape": "Sample weights are not supported",
-        "check_sample_weights_not_overwritten": "Sample weights are not supported",
-        "check_sample_weight_equivalence_on_dense_data": (
-            "Sample weights are not supported"
-        ),
         "check_estimators_pickle": (
             "Pickling does not preserve the fitted model state"
         ),


### PR DESCRIPTION
These arguments should not have been added, now they are gone. This removes the `warm_start` constructor argument that was unsupported and only ever raised. The same goes for the `sample_weights` argument used in `fit()` and friends.

No deprecation cycles because this fixes a bug (arguments should never have been there in the first place).

Towards https://github.com/NVIDIA/cuml/issues/8420