### PR TITLE
Fix support for pytorch inputs

### DIFF
--- a/python/cuml/cuml/internals/validation.py
+++ b/python/cuml/cuml/internals/validation.py
@@ -14,7 +14,7 @@ import pandas as pd
 import scipy.sparse as sp
 import sklearn
 from packaging.version import Version
-from pandas.api.types import is_extension_array_dtype, is_string_dtype
+from pandas.api.types import is_string_dtype
 from sklearn.exceptions import DataConversionWarning
 from sklearn.utils.validation import check_is_fitted
 
@@ -35,25 +35,6 @@ __all__ = (
 )
 
 _CUPY_SUPPORTS_LARGE_SPARSE = Version(cp.__version__) >= Version("14.1.0")
-
-
-def _as_numpy_dtype(dtype):
-    """Normalize pandas extension dtypes for numpy/cupy conversion."""
-    try:
-        return np.dtype(dtype)
-    except TypeError:
-        if is_string_dtype(dtype) or is_extension_array_dtype(dtype):
-            return np.dtype("object")
-        raise
-
-
-def _dataframe_numpy_dtype(dtypes):
-    """Infer a NumPy dtype for dataframe-like inputs."""
-    if all(isinstance(dt, np.dtype) for dt in dtypes):
-        return np.result_type(*dtypes)
-    if any(dt == "object" or is_string_dtype(dt) for dt in dtypes):
-        return np.dtype("object")
-    return None
 
 
 def check_random_seed(random_state) -> int:
@@ -675,7 +656,7 @@ def check_array(
     if dtype is not None:
         if not isinstance(dtype, (list, tuple)):
             dtype = [dtype]
-        dtype = [_as_numpy_dtype(i) for i in dtype]
+        dtype = [np.dtype(i) for i in dtype]
 
     is_sparse = cp_sp.issparse(array) or sp.issparse(array)
     if is_sparse and (
@@ -699,12 +680,26 @@ def check_array(
     # Extract original array type and dtype (when possible)
     array_type = type(array)
     if isinstance(array, (cudf.DataFrame, pd.DataFrame)):
-        array_dtype = _dataframe_numpy_dtype(array.dtypes)
+        if all(isinstance(dt, np.dtype) for dt in array.dtypes):
+            array_dtype = np.result_type(*array.dtypes)
+        elif any(dt == "object" or is_string_dtype(dt) for dt in array.dtypes):
+            array_dtype = np.dtype("object")
+        else:
+            array_dtype = None
     else:
         array_dtype = getattr(array, "dtype", None)
-        if not isinstance(array_dtype, np.dtype) and array_dtype is not None:
-            array_dtype = _as_numpy_dtype(array_dtype)
-        elif not isinstance(array_dtype, np.dtype):
+        if array_dtype is not None and not isinstance(array_dtype, np.dtype):
+            # Try to coerce the dtype to numpy, falling back to None if it's
+            # not a support dtype (pytorch for example has a `dtype` attribute,
+            # but it can't be directly coerced to numpy's.
+            try:
+                array_dtype = np.dtype(array_dtype)
+            except TypeError:
+                if is_string_dtype(array_dtype):
+                    array_dtype = np.dtype("object")
+                else:
+                    array_dtype = None
+        if not isinstance(array_dtype, np.dtype):
             # Objects implementing the numpy array protocol may not expose a
             # ``dtype`` attribute themselves. Normalize these before selecting
             # from the supported dtypes so their represented dtype is preserved.
@@ -1144,7 +1139,7 @@ def check_y(
     if dtype is not None:
         if not isinstance(dtype, (list, tuple)):
             dtype = [dtype]
-        dtype = [_as_numpy_dtype(i) for i in dtype]
+        dtype = [np.dtype(i) for i in dtype]
 
     # Extract the index from `y` (if available)
     if isinstance(y, (pd.DataFrame, pd.Series, cudf.DataFrame, cudf.Series)):

--- a/python/cuml/cuml/internals/validation.py
+++ b/python/cuml/cuml/internals/validation.py
@@ -700,10 +700,14 @@ def check_array(
                 else:
                     array_dtype = None
         if not isinstance(array_dtype, np.dtype):
-            # Objects implementing the numpy array protocol may not expose a
-            # ``dtype`` attribute themselves. Normalize these before selecting
-            # from the supported dtypes so their represented dtype is preserved.
-            if hasattr(array, "__array__"):
+            # Objects implementing __cuda_array_interface__ or __array__ may
+            # not expose a valid ``dtype`` attribute themselves. Normalize
+            # these before selecting from the supported dtypes so their
+            # represented dtype is preserved.
+            if hasattr(array, "__cuda_array_interface__"):
+                array = cp.asarray(array)
+                array_dtype = array.dtype
+            elif hasattr(array, "__array__"):
                 array = np.asarray(array)
                 array_dtype = array.dtype
             else:

--- a/python/cuml/cuml/internals/validation.py
+++ b/python/cuml/cuml/internals/validation.py
@@ -680,6 +680,7 @@ def check_array(
     # Extract original array type and dtype (when possible)
     array_type = type(array)
     if isinstance(array, (cudf.DataFrame, pd.DataFrame)):
+        # Unify dataframe dtypes when possible, None otherwise
         if all(isinstance(dt, np.dtype) for dt in array.dtypes):
             array_dtype = np.result_type(*array.dtypes)
         elif any(dt == "object" or is_string_dtype(dt) for dt in array.dtypes):
@@ -687,11 +688,11 @@ def check_array(
         else:
             array_dtype = None
     else:
+        # Extract and normalize the `dtype` attribute if present. If `dtype` is
+        # present but doesn't coerce to a numpy dtype, fall back to None. For
+        # example, pytorch arrays have a non-numpy-compatible `dtype` attr.
         array_dtype = getattr(array, "dtype", None)
         if array_dtype is not None and not isinstance(array_dtype, np.dtype):
-            # Try to coerce the dtype to numpy, falling back to None if it's
-            # not a support dtype (pytorch for example has a `dtype` attribute,
-            # but it can't be directly coerced to numpy's.
             try:
                 array_dtype = np.dtype(array_dtype)
             except TypeError:
@@ -699,19 +700,20 @@ def check_array(
                     array_dtype = np.dtype("object")
                 else:
                     array_dtype = None
-        if not isinstance(array_dtype, np.dtype):
-            # Objects implementing __cuda_array_interface__ or __array__ may
-            # not expose a valid ``dtype`` attribute themselves. Normalize
-            # these before selecting from the supported dtypes so their
-            # represented dtype is preserved.
+
+        # Non-Series objects implementing __cuda_array_interface__ or __array__
+        # may not expose a valid ``dtype`` attribute themselves. Normalize
+        # these before selecting from the supported dtypes so their represented
+        # dtype is preserved.
+        if array_dtype is None and not isinstance(
+            array, (cudf.Series, pd.Series)
+        ):
             if hasattr(array, "__cuda_array_interface__"):
                 array = cp.asarray(array)
                 array_dtype = array.dtype
             elif hasattr(array, "__array__"):
                 array = np.asarray(array)
                 array_dtype = array.dtype
-            else:
-                array_dtype = None
 
     # Infer proper output dtype
     if array_dtype is not None:

--- a/python/cuml/tests/test_validation.py
+++ b/python/cuml/tests/test_validation.py
@@ -793,6 +793,33 @@ def test_check_array_array_protocol_preserves_dtype(dtype, mem_type):
     assert out.dtype == dtype
 
 
+def test_check_array_non_numpy_dtype_attribute():
+    """Some array implementations (pytorch) have non-numpy-compatible `dtype`
+    attributes. This test checks that these objects may still be ingested
+    through other protocols, and that their unsupported `dtype` attribute
+    doesn't break things."""
+
+    class Float32:
+        pass
+
+    class ArrayLike:
+        def __init__(self, array):
+            self.array = array
+            self.dtype = Float32()
+
+        def __array__(self, dtype=None, copy=None):
+            return self.array
+
+    array = ArrayLike(np.array([[1, 2, 3]], dtype="float32"))
+
+    out = check_array(array, dtype=("float32", "float64"))
+    assert out.dtype == "float32"
+    out = check_array(array, dtype=("float64", "float32"))
+    assert out.dtype == "float32"
+    out = check_array(array, dtype="float64")
+    assert out.dtype == "float64"
+
+
 @example(mem_type="device", dtype="int32", order="C", shape=(3, 4))
 @example(mem_type="host", dtype="float32", order="F", shape=(3,))
 @given(

--- a/python/cuml/tests/test_validation.py
+++ b/python/cuml/tests/test_validation.py
@@ -793,7 +793,8 @@ def test_check_array_array_protocol_preserves_dtype(dtype, mem_type):
     assert out.dtype == dtype
 
 
-def test_check_array_non_numpy_dtype_attribute():
+@pytest.mark.parametrize("mem_type", ["host", "device"])
+def test_check_array_non_numpy_dtype_attribute(mem_type):
     """Some array implementations (pytorch) have non-numpy-compatible `dtype`
     attributes. This test checks that these objects may still be ingested
     through other protocols, and that their unsupported `dtype` attribute
@@ -802,22 +803,44 @@ def test_check_array_non_numpy_dtype_attribute():
     class Float32:
         pass
 
-    class ArrayLike:
-        def __init__(self, array):
-            self.array = array
-            self.dtype = Float32()
+    if mem_type == "host":
 
-        def __array__(self, dtype=None, copy=None):
-            return self.array
+        class ArrayLike:
+            """A array-like class like torch-cpu"""
 
-    array = ArrayLike(np.array([[1, 2, 3]], dtype="float32"))
+            def __init__(self, array):
+                self.array = np.asarray(array, dtype="float32")
+                self.dtype = Float32()
 
-    out = check_array(array, dtype=("float32", "float64"))
+            def __array__(self, dtype=None, copy=None):
+                return self.array
+
+    else:
+
+        class ArrayLike:
+            """A array-like class like torch-gpu"""
+
+            def __init__(self, array):
+                self.array = cp.asarray(array, dtype="float32")
+                self.dtype = Float32()
+
+            def __array__(self, dtype=None, copy=None):
+                raise ValueError("This can't actually be called")
+
+            @property
+            def __cuda_array_interface__(self):
+                return self.array.__cuda_array_interface__
+
+    source_cls = np.ndarray if mem_type == "host" else cp.ndarray
+
+    array = ArrayLike([[1, 2, 3]])
+
+    out = check_array(array, dtype=("float64", "float32"), mem_type=None)
     assert out.dtype == "float32"
-    out = check_array(array, dtype=("float64", "float32"))
-    assert out.dtype == "float32"
-    out = check_array(array, dtype="float64")
+    assert isinstance(out, source_cls)
+    out = check_array(array, dtype="float64", mem_type=None)
     assert out.dtype == "float64"
+    assert isinstance(out, source_cls)
 
 
 @example(mem_type="device", dtype="int32", order="C", shape=(3, 4))

--- a/python/cuml/tests/test_validation.py
+++ b/python/cuml/tests/test_validation.py
@@ -984,6 +984,80 @@ def test_check_array_return_index(kind, ndim, mem_type):
     assert (cp.asnumpy(index) == np.array([1, 3, 5])).all()
 
 
+def xfail_cudf_ext_dtype_bug(*args, strict=True):
+    # TODO: when the test starts xpassing once cudf fixes the issue, remove and
+    # simplify the parametrization below.
+    return pytest.param(
+        *args,
+        marks=pytest.mark.xfail(
+            reason=(
+                "cudf's to_cupy/to_numpy fails on extension dtypes, see "
+                "https://github.com/NVIDIA/cudf/issues/23723"
+            ),
+            strict=strict,
+        ),
+    )
+
+
+@pytest.mark.parametrize(
+    "kind,mem_type,ndim,dtype",
+    [
+        xfail_cudf_ext_dtype_bug("cudf", "host", 1, None, strict=False),
+        xfail_cudf_ext_dtype_bug("cudf", "device", 1, None),
+        xfail_cudf_ext_dtype_bug("cudf", None, 1, None),
+        ("pandas", "host", 1, None),
+        ("pandas", "device", 1, None),
+        ("pandas", None, 1, None),
+        xfail_cudf_ext_dtype_bug("cudf", "host", 1, "float32"),
+        xfail_cudf_ext_dtype_bug("cudf", "device", 1, "float32"),
+        xfail_cudf_ext_dtype_bug("cudf", None, 1, "float32"),
+        ("pandas", "host", 1, "float32"),
+        ("pandas", "device", 1, "float32"),
+        ("pandas", None, 1, "float32"),
+        xfail_cudf_ext_dtype_bug("cudf", "host", 2, None),
+        xfail_cudf_ext_dtype_bug("cudf", "device", 2, None),
+        xfail_cudf_ext_dtype_bug("cudf", None, 2, None),
+        ("pandas", "host", 2, None),
+        ("pandas", "device", 2, None),
+        ("pandas", None, 2, None),
+        xfail_cudf_ext_dtype_bug("cudf", "host", 2, "float32"),
+        xfail_cudf_ext_dtype_bug("cudf", "device", 2, "float32"),
+        xfail_cudf_ext_dtype_bug("cudf", None, 2, "float32"),
+        ("pandas", "host", 2, "float32"),
+        ("pandas", "device", 2, "float32"),
+        ("pandas", None, 2, "float32"),
+    ],
+)
+def test_check_array_dataframe_extension_dtype(kind, mem_type, ndim, dtype):
+    xdf = cudf if kind == "cudf" else pd
+    array = xdf.Series([1, 2, None], index=[1, 3, 5], dtype="Int32")
+    if ndim == 2:
+        array = array.to_frame()
+
+    out, index = check_array(
+        array,
+        dtype=dtype,
+        mem_type=mem_type,
+        ensure_2d=False,
+        ensure_all_finite="allow-nan",
+        return_index=True,
+    )
+    if mem_type is None:
+        out_xdf = xdf
+    else:
+        out_xdf = cudf if mem_type == "device" else pd
+
+    if xdf is cudf:
+        sol = array.to_pandas().to_numpy(dtype=dtype)
+    else:
+        sol = array.to_numpy(dtype=dtype)
+
+    np.testing.assert_array_equal(cp.asnumpy(out), sol)
+
+    assert isinstance(index, out_xdf.Index)
+    assert (cp.asnumpy(index) == np.array([1, 3, 5])).all()
+
+
 @pytest.mark.parametrize("kind", ["numpy", "cudf", "pandas"])
 @pytest.mark.parametrize("mem_type", ["device", "host", None])
 def test_check_array_object_dtype(kind, mem_type):


### PR DESCRIPTION
Previously these weren't natively supported since the `dtype` attribute wasn't compatible with numpy's `dtype` objects. This fixes that and adds a test.

Also simplifies a bit of our dtype inference pipeline, removing some cruft that showed up in the pandas 3 transition.

Also adds a new test for extension dtype handling, with several cases xfailed until an upstream bug in cudf is fixed.

Fixes #6276.