### PR TITLE
X-ORG-8423: publish-api-docs version-map uses vars

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -95,7 +95,7 @@ jobs:
     with:
       docs-projects: cuml,libcuml
       dry-run: false
-      version-map: '{"26.04": "legacy", "26.06": "stable"}'
+      version-map: ${{ vars.VERSION_MAP }}
   python-build:
     needs: [build-details, cpp-build]
     permissions:

--- a/.github/workflows/pr.yaml
+++ b/.github/workflows/pr.yaml
@@ -516,7 +516,7 @@ jobs:
     with:
       docs-projects: cuml,libcuml
       dry-run: true
-      version-map: '{"26.04": "legacy", "26.06": "stable"}'
+      version-map: ${{ vars.VERSION_MAP }}
   wheel-build-libcuml:
     needs: [build-details, checks]
     permissions:


### PR DESCRIPTION
Contributes to #8423 

Replace the (currently unused) hard-coded `version-map` with one we can set via `vars`.

This decouples updating the `versions.json` that powers the docs version switcher from code changes, making the docs release process simpler.

N.B. I'll be updating the docs publishing shared workflow to use this version map, but it currently doesn't.