### PR TITLE
Use CMAKE_MESSAGE_CONTEXT to cleanup CMake logging

### DIFF
--- a/cpp/CMakeLists.txt
+++ b/cpp/CMakeLists.txt
@@ -32,6 +32,10 @@ set(CMAKE_CXX_SCAN_FOR_MODULES OFF)
 # Write the version header
 rapids_cmake_write_version_file(include/cuml/version_config.hpp)
 
+# Prefix CMake messages with the project context to make CI logs easier to diagnose.
+set(CMAKE_MESSAGE_CONTEXT_SHOW ON)
+list(APPEND CMAKE_MESSAGE_CONTEXT "CUML_CPP")
+
 # ##################################################################################################
 # * build type ---------------------------------------------------------------
 
@@ -79,25 +83,25 @@ option(CUML_NVFOREST_CLONE_ON_PIN
        "Explicitly clone nvForest branch when pinned to non-feature branch" ON
 )
 
-message(VERBOSE "CUML_CPP: Building libcuml shared library: ${BUILD_CUML_CPP_LIBRARY}")
-message(VERBOSE "CUML_CPP: Building cuML algorithm tests: ${BUILD_CUML_TESTS}")
-message(VERBOSE "CUML_CPP: Building cuML multigpu algorithm tests: ${BUILD_CUML_MG_TESTS}")
-message(VERBOSE "CUML_CPP: Building ml-prims tests: ${BUILD_PRIMS_TESTS}")
-message(VERBOSE "CUML_CPP: Building C++ API usage examples: ${BUILD_CUML_EXAMPLES}")
-message(VERBOSE "CUML_CPP: Building cuML C++ benchmark tests: ${BUILD_CUML_BENCH}")
+message(VERBOSE "Building libcuml shared library: ${BUILD_CUML_CPP_LIBRARY}")
+message(VERBOSE "Building cuML algorithm tests: ${BUILD_CUML_TESTS}")
+message(VERBOSE "Building cuML multigpu algorithm tests: ${BUILD_CUML_MG_TESTS}")
+message(VERBOSE "Building ml-prims tests: ${BUILD_PRIMS_TESTS}")
+message(VERBOSE "Building C++ API usage examples: ${BUILD_CUML_EXAMPLES}")
+message(VERBOSE "Building cuML C++ benchmark tests: ${BUILD_CUML_BENCH}")
 message(VERBOSE
-        "CUML_CPP: Enabling detection of conda environment for dependencies: ${DETECT_CONDA_ENV}"
+        "Enabling detection of conda environment for dependencies: ${DETECT_CONDA_ENV}"
 )
-message(VERBOSE "CUML_CPP: Disabling OpenMP: ${DISABLE_OPENMP}")
-message(VERBOSE "CUML_CPP: Enabling kernel resource usage info: ${KERNEL_INFO}")
-message(VERBOSE "CUML_CPP: Enabling kernelinfo in nvcc: ${CUDA_ENABLE_KERNEL_INFO}")
-message(VERBOSE "CUML_CPP: Enabling lineinfo in nvcc: ${CUDA_ENABLE_LINE_INFO}")
-message(VERBOSE "CUML_CPP: Enabling nvtx markers: ${NVTX}")
-message(VERBOSE "CUML_CPP: Disabling all mnmg components and comms libraries: ${SINGLEGPU}")
-message(VERBOSE "CUML_CPP: Cache build artifacts with ccache: ${USE_CCACHE}")
-message(VERBOSE "CUML_CPP: Statically link the CUDA math libraries: ${CUDA_STATIC_MATH_LIBRARIES}")
-message(VERBOSE "CUML_CPP: Build and statically link CUVS libraries: ${CUML_USE_CUVS_STATIC}")
-message(VERBOSE "CUML_CPP: Build and statically link Treelite library: ${CUML_USE_TREELITE_STATIC}")
+message(VERBOSE "Disabling OpenMP: ${DISABLE_OPENMP}")
+message(VERBOSE "Enabling kernel resource usage info: ${KERNEL_INFO}")
+message(VERBOSE "Enabling kernelinfo in nvcc: ${CUDA_ENABLE_KERNEL_INFO}")
+message(VERBOSE "Enabling lineinfo in nvcc: ${CUDA_ENABLE_LINE_INFO}")
+message(VERBOSE "Enabling nvtx markers: ${NVTX}")
+message(VERBOSE "Disabling all mnmg components and comms libraries: ${SINGLEGPU}")
+message(VERBOSE "Cache build artifacts with ccache: ${USE_CCACHE}")
+message(VERBOSE "Statically link the CUDA math libraries: ${CUDA_STATIC_MATH_LIBRARIES}")
+message(VERBOSE "Build and statically link CUVS libraries: ${CUML_USE_CUVS_STATIC}")
+message(VERBOSE "Build and statically link Treelite library: ${CUML_USE_TREELITE_STATIC}")
 
 set(CUML_ALGORITHMS
     "ALL"
@@ -105,7 +109,7 @@ set(CUML_ALGORITHMS
       STRING
       "Choose which algorithms are built into libcuml.so. Can specify individual algorithms or groups in a semicolon-separated list."
 )
-message(VERBOSE "CUML_CPP: Building libcuml with algorithms: '${CUML_ALGORITHMS}'.")
+message(VERBOSE "Building libcuml with algorithms: '${CUML_ALGORITHMS}'.")
 
 # Set RMM logging level
 set(RMM_LOGGING_LEVEL
@@ -115,7 +119,7 @@ set(RMM_LOGGING_LEVEL
 set_property(
   CACHE RMM_LOGGING_LEVEL PROPERTY STRINGS "TRACE" "DEBUG" "INFO" "WARN" "ERROR" "CRITICAL" "OFF"
 )
-message(VERBOSE "CUML_CPP: RMM_LOGGING_LEVEL = '${RMM_LOGGING_LEVEL}'.")
+message(VERBOSE "RMM_LOGGING_LEVEL = '${RMM_LOGGING_LEVEL}'.")
 
 # Set logging level
 set(LIBCUML_LOGGING_LEVEL
@@ -126,7 +130,10 @@ set_property(
   CACHE LIBCUML_LOGGING_LEVEL PROPERTY STRINGS "TRACE" "DEBUG" "INFO" "WARN" "ERROR" "CRITICAL"
                                        "OFF"
 )
-message(VERBOSE "CUML: LIBCUML_LOGGING_LEVEL = '${LIBCUML_LOGGING_LEVEL}'.")
+
+list(APPEND CMAKE_MESSAGE_CONTEXT "CUML")
+message(VERBOSE "LIBCUML_LOGGING_LEVEL = '${LIBCUML_LOGGING_LEVEL}'.")
+list(POP_BACK CMAKE_MESSAGE_CONTEXT)
 
 if(BUILD_CUML_TESTS
    OR BUILD_CUML_MG_TESTS
@@ -152,7 +159,7 @@ if(DETECT_CONDA_ENV)
   rapids_cmake_support_conda_env(conda_env MODIFY_PREFIX_PATH)
   if(CMAKE_INSTALL_PREFIX_INITIALIZED_TO_DEFAULT AND DEFINED ENV{CONDA_PREFIX})
     message(
-      STATUS "CUML_CPP: No CMAKE_INSTALL_PREFIX argument detected, setting to: $ENV{CONDA_PREFIX}"
+      STATUS "No CMAKE_INSTALL_PREFIX argument detected, setting to: $ENV{CONDA_PREFIX}"
     )
     set(CMAKE_INSTALL_PREFIX "$ENV{CONDA_PREFIX}")
   endif()
@@ -171,7 +178,7 @@ endif()
 if(NOT DISABLE_OPENMP)
   find_package(OpenMP)
   if(OpenMP_FOUND)
-    message(STATUS "CUML_CPP: OpenMP found in ${OPENMP_INCLUDE_DIRS}")
+    message(STATUS "OpenMP found in ${OPENMP_INCLUDE_DIRS}")
     list(APPEND CUML_CXX_FLAGS ${OpenMP_CXX_FLAGS})
   endif()
 endif()
@@ -208,8 +215,8 @@ endif()
 
 # SingleGPU build disables comms components
 if(SINGLEGPU)
-  message(STATUS "CUML_CPP: Detected SINGLEGPU build option")
-  message(STATUS "CUML_CPP: Disabling Multi-GPU components and comms libraries")
+  message(STATUS "Detected SINGLEGPU build option")
+  message(STATUS "Disabling Multi-GPU components and comms libraries")
   set(BUILD_CUML_MG_TESTS OFF)
 endif()
 
@@ -220,10 +227,12 @@ if(USE_CCACHE)
 endif()
 
 if(NOT BUILD_SHARED_LIBS AND CUML_COMPILE_DYNAMIC_ONLY)
+  list(APPEND CMAKE_MESSAGE_CONTEXT "cuML")
   message(
     VERBOSE
-    "cuML: Ignoring `BUILD_SHARED_LIBS` and forcing shared library due to `CUML_COMPILE_DYNAMIC_ONLY`"
+    "Ignoring `BUILD_SHARED_LIBS` and forcing shared library due to `CUML_COMPILE_DYNAMIC_ONLY`"
   )
+  list(POP_BACK CMAKE_MESSAGE_CONTEXT)
 endif()
 
 if(BUILD_CUML_CPP_LIBRARY)
@@ -873,3 +882,6 @@ add_doxygen_target(
   IN_DOXYFILE Doxyfile.in OUT_DOXYFILE ${CMAKE_CURRENT_SOURCE_DIR}/Doxyfile CWD
   ${CMAKE_CURRENT_SOURCE_DIR}
 )
+
+# Restore the outer CMAKE_MESSAGE_CONTEXT.
+list(POP_BACK CMAKE_MESSAGE_CONTEXT)

--- a/cpp/cmake/modules/ConfigureCUDA.cmake
+++ b/cpp/cmake/modules/ConfigureCUDA.cmake
@@ -5,6 +5,9 @@
 # cmake-format: on
 # =============================================================================
 
+# Prefix CMake messages with the project context to make CI logs easier to diagnose.
+list(APPEND CMAKE_MESSAGE_CONTEXT "CUML")
+
 if(CMAKE_COMPILER_IS_GNUCXX)
   list(APPEND CUML_CXX_FLAGS -Wall -Werror -Wno-unknown-pragmas)
   if(CUML_BUILD_TESTS OR CUML_BUILD_BENCHMARKS)
@@ -50,6 +53,9 @@ endif()
 
 # Debug options
 if(CMAKE_BUILD_TYPE MATCHES Debug)
-  message(VERBOSE "CUML: Building with debugging flags")
+  message(VERBOSE "Building with debugging flags")
   list(APPEND CUML_CUDA_FLAGS -G -Xcompiler=-rdynamic)
 endif()
+
+# Restore the outer CMAKE_MESSAGE_CONTEXT.
+list(POP_BACK CMAKE_MESSAGE_CONTEXT)

--- a/cpp/cmake/thirdparty/get_cuvs.cmake
+++ b/cpp/cmake/thirdparty/get_cuvs.cmake
@@ -7,16 +7,19 @@
 
 set(CUML_MIN_VERSION_cuvs "${CUML_VERSION_MAJOR}.${CUML_VERSION_MINOR}.00")
 
+# Prefix CMake messages with the project context to make CI logs easier to diagnose.
+list(APPEND CMAKE_MESSAGE_CONTEXT "CUML")
+
 function(find_and_configure_cuvs)
     set(oneValueArgs VERSION FORK PINNED_TAG EXCLUDE_FROM_ALL USE_CUVS_STATIC COMPILE_LIBRARY CLONE_ON_PIN)
     cmake_parse_arguments(PKG "${options}" "${oneValueArgs}"
             "${multiValueArgs}" ${ARGN} )
 
     if(PKG_CLONE_ON_PIN AND NOT PKG_PINNED_TAG STREQUAL "${rapids-cmake-checkout-tag}")
-        message(STATUS "CUML: CUVS pinned tag found: ${PKG_PINNED_TAG}. Cloning cuvs locally.")
+        message(STATUS "CUVS pinned tag found: ${PKG_PINNED_TAG}. Cloning cuvs locally.")
         set(CPM_DOWNLOAD_cuvs ON)
     elseif(PKG_USE_CUVS_STATIC AND (NOT CPM_cuvs_SOURCE))
-        message(STATUS "CUML: Cloning cuvs locally to build static libraries.")
+        message(STATUS "Cloning cuvs locally to build static libraries.")
         set(CPM_DOWNLOAD_cuvs ON)
     else()
         message(STATUS "Not cloning cuvs locally")
@@ -49,9 +52,9 @@ function(find_and_configure_cuvs)
     )
 
     if(cuvs_ADDED)
-        message(VERBOSE "CUML: Using CUVS located in ${cuvs_SOURCE_DIR}")
+        message(VERBOSE "Using CUVS located in ${cuvs_SOURCE_DIR}")
     else()
-        message(VERBOSE "CUML: Using CUVS located in ${cuvs_DIR}")
+        message(VERBOSE "Using CUVS located in ${cuvs_DIR}")
     endif()
 
 
@@ -71,3 +74,6 @@ find_and_configure_cuvs(VERSION          ${CUML_MIN_VERSION_cuvs}
       COMPILE_LIBRARY  ${CUML_CUVS_COMPILED}
       USE_CUVS_STATIC  ${CUML_USE_CUVS_STATIC}
       )
+
+# Restore the outer CMAKE_MESSAGE_CONTEXT.
+list(POP_BACK CMAKE_MESSAGE_CONTEXT)

--- a/cpp/cmake/thirdparty/get_nvforest.cmake
+++ b/cpp/cmake/thirdparty/get_nvforest.cmake
@@ -7,13 +7,16 @@
 
 set(CUML_MIN_VERSION_nvforest "${CUML_VERSION_MAJOR}.${CUML_VERSION_MINOR}.00")
 
+# Prefix CMake messages with the project context to make CI logs easier to diagnose.
+list(APPEND CMAKE_MESSAGE_CONTEXT "CUML")
+
 function(find_and_configure_nvforest)
     set(oneValueArgs VERSION FORK PINNED_TAG EXCLUDE_FROM_ALL CLONE_ON_PIN)
     cmake_parse_arguments(PKG "${options}" "${oneValueArgs}"
             "${multiValueArgs}" ${ARGN} )
 
     if(PKG_CLONE_ON_PIN AND NOT PKG_PINNED_TAG STREQUAL "${rapids-cmake-checkout-tag}")
-        message(STATUS "CUML: nvForest pinned tag found: ${PKG_PINNED_TAG}. Cloning nvForest locally.")
+        message(STATUS "nvForest pinned tag found: ${PKG_PINNED_TAG}. Cloning nvForest locally.")
         set(CPM_DOWNLOAD_nvforest ON)
     endif()
 
@@ -31,9 +34,9 @@ function(find_and_configure_nvforest)
     )
 
     if(nvforest_ADDED)
-        message(VERBOSE "CUML: Using nvForest located in ${nvforest_SOURCE_DIR}")
+        message(VERBOSE "Using nvForest located in ${nvforest_SOURCE_DIR}")
     else()
-        message(VERBOSE "CUML: Using nvForest located in ${nvforest_DIR}")
+        message(VERBOSE "Using nvForest located in ${nvforest_DIR}")
     endif()
 
 endfunction()
@@ -50,3 +53,6 @@ find_and_configure_nvforest(VERSION          ${CUML_MIN_VERSION_nvforest}
         # even if it's already installed.
         CLONE_ON_PIN     ${CUML_NVFOREST_CLONE_ON_PIN}
 )
+
+# Restore the outer CMAKE_MESSAGE_CONTEXT.
+list(POP_BACK CMAKE_MESSAGE_CONTEXT)

--- a/cpp/cmake/thirdparty/get_raft.cmake
+++ b/cpp/cmake/thirdparty/get_raft.cmake
@@ -7,13 +7,16 @@
 
 set(CUML_MIN_VERSION_raft "${CUML_VERSION_MAJOR}.${CUML_VERSION_MINOR}.00")
 
+# Prefix CMake messages with the project context to make CI logs easier to diagnose.
+list(APPEND CMAKE_MESSAGE_CONTEXT "CUML")
+
 function(find_and_configure_raft)
     set(oneValueArgs VERSION FORK PINNED_TAG EXCLUDE_FROM_ALL CLONE_ON_PIN NVTX)
     cmake_parse_arguments(PKG "${options}" "${oneValueArgs}"
             "${multiValueArgs}" ${ARGN} )
 
     if(PKG_CLONE_ON_PIN AND NOT PKG_PINNED_TAG STREQUAL "${rapids-cmake-checkout-tag}")
-        message(STATUS "CUML: RAFT pinned tag found: ${PKG_PINNED_TAG}. Cloning raft locally.")
+        message(STATUS "RAFT pinned tag found: ${PKG_PINNED_TAG}. Cloning raft locally.")
         set(CPM_DOWNLOAD_raft ON)
     endif()
 
@@ -26,7 +29,7 @@ function(find_and_configure_raft)
     # the raft-config.cmake re-evaluates the RAFT_NVTX value
     set(RAFT_NVTX ${PKG_NVTX})
 
-    message(VERBOSE "CUML: raft FIND_PACKAGE_ARGUMENTS COMPONENTS ${RAFT_COMPONENTS}")
+    message(VERBOSE "raft FIND_PACKAGE_ARGUMENTS COMPONENTS ${RAFT_COMPONENTS}")
 
     rapids_cpm_find(raft ${PKG_VERSION}
       GLOBAL_TARGETS      raft::raft
@@ -44,9 +47,9 @@ function(find_and_configure_raft)
     )
 
     if(raft_ADDED)
-        message(VERBOSE "CUML: Using RAFT located in ${raft_SOURCE_DIR}")
+        message(VERBOSE "Using RAFT located in ${raft_SOURCE_DIR}")
     else()
-        message(VERBOSE "CUML: Using RAFT located in ${raft_DIR}")
+        message(VERBOSE "Using RAFT located in ${raft_DIR}")
     endif()
 
 
@@ -65,3 +68,6 @@ find_and_configure_raft(VERSION          ${CUML_MIN_VERSION_raft}
       CLONE_ON_PIN     ${CUML_RAFT_CLONE_ON_PIN}
       NVTX             ${NVTX}
       )
+
+# Restore the outer CMAKE_MESSAGE_CONTEXT.
+list(POP_BACK CMAKE_MESSAGE_CONTEXT)

--- a/python/cuml/CMakeLists.txt
+++ b/python/cuml/CMakeLists.txt
@@ -26,15 +26,18 @@ project(
 set(CMAKE_CXX_STANDARD 20)
 set(CMAKE_CXX_STANDARD_REQUIRED ON)
 
+# Prefix CMake messages with the project context to make CI logs easier to diagnose.
+set(CMAKE_MESSAGE_CONTEXT_SHOW ON)
+list(APPEND CMAKE_MESSAGE_CONTEXT "CUML_PY")
+
 # ##################################################################################################
 # * User Options  --------------------------------------------------------------
 option(CUML_UNIVERSAL "Build all cuML Python components." ON)
 option(SINGLEGPU "Disable all mnmg components and comms libraries" OFF)
 option(USE_LIBCUML_WHEEL "Use libcuml wheel to provide some dependencies" OFF)
 
-# todo: use CMAKE_MESSAGE_CONTEXT for prefix for logging.
-# https://github.com/rapidsai/cuml/issues/4843
-message(VERBOSE "CUML_PY: Disabling all mnmg components and comms libraries: ${SINGLEGPU}")
+
+message(VERBOSE "Disabling all mnmg components and comms libraries: ${SINGLEGPU}")
 
 set(CUML_ALGORITHMS
     "ALL"
@@ -87,7 +90,7 @@ set(cuml_mg_libraries cuml::${CUML_CPP_TARGET})
 include("${CUML_CPP_SRC}/cmake/modules/ConfigureAlgorithms.cmake")
 include(cmake/ConfigureCythonAlgorithms.cmake)
 
-message(VERBOSE "CUML_PY: Building cuML with algorithms: '${CUML_ALGORITHMS}'.")
+message(VERBOSE "Building cuML with algorithms: '${CUML_ALGORITHMS}'.")
 
 include(rapids-cython-core)
 rapids_cython_init()
@@ -111,3 +114,6 @@ add_subdirectory(cuml/tsa)
 
 # Include the pth file in the built wheel
 install(FILES "_zz_cuml_accel.pth" DESTINATION ".")
+
+# Restore the outer CMAKE_MESSAGE_CONTEXT.
+list(POP_BACK CMAKE_MESSAGE_CONTEXT)


### PR DESCRIPTION
## Description

<!-- Provide a standalone description of changes in this PR. -->
<!-- Why is this change required? What problem does it solve? -->

Closes #4843

**Problem**

CMake configure logs prefix each `message()` with a hardcoded keyword (e.g. `CUML_CPP:`, `CUML_PY:`, `CUML:`, `cuML:`) so CI failures can be attributed to the right component. The keyword is repeated in every statement, which is error-prone and has already led to inconsistencies:

- `LIBCUML_LOGGING_LEVEL` used `CUML:` and `CUML_COMPILE_DYNAMIC_ONLY` used a lowercase `cuML:` prefix, while everything else in the same file used `CUML_CPP:`.
- `Not cloning cuvs locally` in `get_cuvs.cmake` had no prefix at all.

**Solution**

Use CMake's `CMAKE_MESSAGE_CONTEXT`, together with `CMAKE_MESSAGE_CONTEXT_SHOW`, so each context keyword is declared once per scope instead of being repeated in every `message()`:

- `cpp/CMakeLists.txt` pushes `CUML_CPP`; its messages now render as `[CUML_CPP] ...`.
- `python/cuml/CMakeLists.txt` pushes `CUML_PY`; its messages render as `[CUML_PY] ...`.
- `get_raft.cmake`, `get_cuvs.cmake`, `get_nvforest.cmake`, and `ConfigureCUDA.cmake` push a nested `CUML` context, so their messages render as `[CUML_CPP.CUML] ...`.
- `CMAKE_MESSAGE_CONTEXT_SHOW` is set only in the two top-level CMake projects (`cpp` and `python/cuml`); the included third-party files inherit it and do not repeat the setting.

**Special cases**

- The existing lowercase `cuML:` prefix on the `CUML_COMPILE_DYNAMIC_ONLY` message is preserved as a (lowercase) nested context token, keeping the log output faithful to the original.
- The previously-unprefixed `Not cloning cuvs locally` message now automatically inherits the file's `CUML` context and renders as `[CUML_CPP.CUML] Not cloning cuvs locally`, making it consistent with its sibling messages without any manual text change.

**Files changed**

- `cpp/CMakeLists.txt`
- `python/cuml/CMakeLists.txt`
- `cpp/cmake/modules/ConfigureCUDA.cmake`
- `cpp/cmake/thirdparty/get_raft.cmake`
- `cpp/cmake/thirdparty/get_cuvs.cmake`
- `cpp/cmake/thirdparty/get_nvforest.cmake`

## Checklist

- [x] I am familiar with the Contributing Guide.
- [x] New or existing tests cover these changes. (CMake-only logging change; no new tests required)
- [x] The documentation is up to date with these changes.
