### PR TITLE
More `get_feature_names_out` support

### DIFF
--- a/python/cuml/cuml/_thirdparty/sklearn/preprocessing/_imputation.py
+++ b/python/cuml/cuml/_thirdparty/sklearn/preprocessing/_imputation.py
@@ -30,7 +30,11 @@ from cuml.internals.mixins import (
     _ensure_transformer_tags,
 )
 from cuml.internals.outputs import mlfunc, ReflectedAttr
-from cuml.internals.validation import check_is_fitted, check_inputs
+from cuml.internals.validation import (
+    check_is_fitted,
+    check_inputs,
+    check_input_features,
+)
 
 from ....thirdparty_adapters import (
     _get_mask,
@@ -488,6 +492,29 @@ class SimpleImputer(SparseInputTagMixin, AllowNaNTagMixin,
         X = super()._concatenate_indicator(X, X_indicator)
         return X
 
+    @mlfunc(convert_output=False)
+    def get_feature_names_out(self, input_features=None):
+        """Get output feature names for transformation.
+
+        Parameters
+        ----------
+        input_features : array-like of str or None, default=None
+            Input feature names.
+
+        Returns
+        -------
+        feature_names_out : numpy.ndarray of str objects.
+            Transformed feature names.
+        """
+        check_is_fitted(self)
+        input_features = check_input_features(self, input_features)
+        non_missing_mask = np.logical_not(_get_mask(self.statistics_, np.nan)).get()
+        names = input_features[non_missing_mask]
+        if self.add_indicator:
+            indicator_names = self.indicator_.get_feature_names_out(input_features)
+            names = cpu_np.concatenate([names, indicator_names])
+        return names
+
 
 class MissingIndicator(AllowNaNTagMixin,
                        SparseInputTagMixin,
@@ -757,6 +784,31 @@ class MissingIndicator(AllowNaNTagMixin,
                 imputer_mask = imputer_mask[:, self.features_]
 
         return imputer_mask
+
+    @mlfunc(convert_output=False)
+    def get_feature_names_out(self, input_features=None):
+        """Get output feature names for transformation.
+
+        Parameters
+        ----------
+        input_features : array-like of str or None, default=None
+            Input feature names.
+
+        Returns
+        -------
+        feature_names_out : numpy.ndarray of str objects.
+            Transformed feature names.
+        """
+        check_is_fitted(self)
+        input_features = check_input_features(self, input_features)
+        prefix = self.__class__.__name__.lower()
+        return cpu_np.asarray(
+            [
+                f"{prefix}_{feature_name}"
+                for feature_name in input_features[self.features_.get()]
+            ],
+            dtype=object,
+        )
 
     @mlfunc(set_input_type=True)
     def fit_transform(self, X, y=None):

--- a/python/cuml/cuml/manifold/spectral_embedding.pyx
+++ b/python/cuml/cuml/manifold/spectral_embedding.pyx
@@ -4,6 +4,7 @@
 #
 import cupy as cp
 import cupyx.scipy.sparse as cp_sp
+from sklearn.base import ClassNamePrefixFeaturesOutMixin
 
 from cuml.internals.base import Base, get_handle
 from cuml.internals.interop import InteropMixin, UnsupportedOnGPU
@@ -50,7 +51,12 @@ cdef extern from "cuml/manifold/spectral_embedding.hpp" \
         device_matrix_view[float, int, col_major] embedding) except +
 
 
-class SpectralEmbedding(InteropMixin, CMajorInputTagMixin, Base):
+class SpectralEmbedding(
+    InteropMixin,
+    CMajorInputTagMixin,
+    ClassNamePrefixFeaturesOutMixin,
+    Base,
+):
     """Spectral embedding for non-linear dimensionality reduction.
 
     Forms an affinity matrix given by the specified function and
@@ -172,6 +178,13 @@ class SpectralEmbedding(InteropMixin, CMajorInputTagMixin, Base):
             "embedding_": self.embedding_.get(order="F"),
             **super()._attrs_to_cpu(model),
         }
+
+    @property
+    @mlfunc(convert_output=False)
+    def _n_features_out(self):
+        """Number of transformed output features."""
+        # Exposed to support sklearn's `get_feature_names_out`
+        return self.embedding_.shape[1]
 
     @mlfunc(preserve_index=True)
     def fit_transform(self, X, y=None):

--- a/python/cuml/cuml/manifold/t_sne.pyx
+++ b/python/cuml/cuml/manifold/t_sne.pyx
@@ -3,6 +3,7 @@
 import warnings
 
 import cupy as cp
+from sklearn.base import ClassNamePrefixFeaturesOutMixin
 
 from cuml.common.doc_utils import generate_docstring
 from cuml.common.sparse import is_sparse
@@ -235,6 +236,7 @@ cdef _init_params(self, int n_samples, TSNEParams &params):
 class TSNE(InteropMixin,
            CMajorInputTagMixin,
            SparseInputTagMixin,
+           ClassNamePrefixFeaturesOutMixin,
            Base):
     """
     t-SNE (T-Distributed Stochastic Neighbor Embedding) is an extremely
@@ -549,10 +551,11 @@ class TSNE(InteropMixin,
         self.precomputed_knn = precomputed_knn
 
     @property
+    @mlfunc(convert_output=False)
     def _n_features_out(self):
         """Number of transformed output features."""
         # Exposed to support sklearn's `get_feature_names_out`
-        return self.embedding_.shape[1]
+        return self.embedding_.array.shape[1]
 
     @generate_docstring(skip_parameters_heading=True,
                         X='dense_sparse')

--- a/python/cuml/cuml/preprocessing/_target_encoder.py
+++ b/python/cuml/cuml/preprocessing/_target_encoder.py
@@ -20,6 +20,7 @@ from cuml.internals.validation import (
     check_consistent_length,
     check_cudf,
     check_features,
+    check_input_features,
     check_is_fitted,
     check_random_seed,
 )
@@ -256,6 +257,25 @@ class TargetEncoder(InteropMixin, Base):
         """
         self.fit(X, y, fold_ids=fold_ids)
         return self.train_encode
+
+    def get_feature_names_out(self, input_features=None):
+        """Get output feature names for transformation.
+
+        Parameters
+        ----------
+        input_features : array-like of str or None, default=None
+            Input feature names.
+
+        Returns
+        -------
+        feature_names_out : numpy.ndarray of str objects.
+            Transformed feature names.
+        """
+        check_is_fitted(self)
+        input_features = check_input_features(self, input_features)
+        if self.multi_feature_mode == "independent":
+            return input_features
+        return np.asarray(["targetencoder0"], dtype=object)
 
     @mlfunc(preserve_index=True)
     def transform(self, X):

--- a/python/cuml/tests/test_preprocessing.py
+++ b/python/cuml/tests/test_preprocessing.py
@@ -1334,3 +1334,24 @@ def test_kbins_discretizer_get_feature_names_out(encode):
     res = cu_model.get_feature_names_out()
     sol = sk_model.get_feature_names_out()
     np.testing.assert_array_equal(res, sol)
+
+
+@pytest.mark.parametrize("names", [None, ["a", "b"]])
+def test_missing_indicator_get_feature_names_out(names):
+    X = np.array([[np.nan, 1], [0, 1], [1, np.nan]])
+    cu_model = cuMissingIndicator().fit(X)
+    sk_model = skMissingIndicator().fit(X)
+    res = cu_model.get_feature_names_out(names)
+    sol = sk_model.get_feature_names_out(names)
+    np.testing.assert_array_equal(res, sol)
+
+
+@pytest.mark.parametrize("names", [None, ["a", "b"]])
+@pytest.mark.parametrize("add_indicator", [False, True])
+def test_simple_imputer_get_feature_names_out(add_indicator, names):
+    X = np.array([[np.nan, 1], [0, 1], [1, np.nan]])
+    cu_model = cuSimpleImputer(add_indicator=add_indicator).fit(X)
+    sk_model = skSimpleImputer(add_indicator=add_indicator).fit(X)
+    res = cu_model.get_feature_names_out(names)
+    sol = sk_model.get_feature_names_out(names)
+    np.testing.assert_array_equal(res, sol)

--- a/python/cuml/tests/test_sklearn_compatibility.py
+++ b/python/cuml/tests/test_sklearn_compatibility.py
@@ -352,6 +352,7 @@ GET_FEATURE_NAMES_OUT_ESTIMATORS = [
     ColumnTransformer(transformers=[("trans1", PolynomialFeatures(), [0, 1])]),
     SimpleImputer(),
     MissingIndicator(),
+    TargetEncoder(multi_feature_mode="independent"),
 ]
 
 GET_FEATURE_NAMES_OUT_XFAILS = {}

--- a/python/cuml/tests/test_sklearn_compatibility.py
+++ b/python/cuml/tests/test_sklearn_compatibility.py
@@ -335,6 +335,7 @@ GET_FEATURE_NAMES_OUT_ESTIMATORS = [
     SparseRandomProjection(n_components=2),
     UMAP(n_components=2),
     TSNE(n_components=2),
+    SpectralEmbedding(n_components=2),
     Binarizer(),
     KernelCenterer(),
     MaxAbsScaler(),

--- a/python/cuml/tests/test_sklearn_compatibility.py
+++ b/python/cuml/tests/test_sklearn_compatibility.py
@@ -350,6 +350,8 @@ GET_FEATURE_NAMES_OUT_ESTIMATORS = [
     PolynomialFeatures(),
     KBinsDiscretizer(),
     ColumnTransformer(transformers=[("trans1", PolynomialFeatures(), [0, 1])]),
+    SimpleImputer(),
+    MissingIndicator(),
 ]
 
 GET_FEATURE_NAMES_OUT_XFAILS = {}

--- a/python/cuml/tests/test_sklearn_compatibility.py
+++ b/python/cuml/tests/test_sklearn_compatibility.py
@@ -334,6 +334,7 @@ GET_FEATURE_NAMES_OUT_ESTIMATORS = [
     GaussianRandomProjection(n_components=2),
     SparseRandomProjection(n_components=2),
     UMAP(n_components=2),
+    TSNE(n_components=2),
     Binarizer(),
     KernelCenterer(),
     MaxAbsScaler(),

--- a/python/cuml/tests/test_spectral_embedding.py
+++ b/python/cuml/tests/test_spectral_embedding.py
@@ -1,4 +1,4 @@
-# SPDX-FileCopyrightText: Copyright (c) 2025-2026, NVIDIA CORPORATION.
+# SPDX-FileCopyrightText: Copyright (c) 2025-2026, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
 # SPDX-License-Identifier: Apache-2.0
 #
 
@@ -7,7 +7,7 @@ import cupyx.scipy.sparse as cp_sp
 import numpy as np
 import pytest
 import scipy.sparse as sp
-from sklearn.datasets import load_digits, make_circles
+from sklearn.datasets import load_digits, make_blobs, make_circles
 from sklearn.manifold import SpectralEmbedding as skSpectralEmbedding
 from sklearn.manifold import trustworthiness
 from sklearn.metrics import pairwise_distances
@@ -330,3 +330,11 @@ def test_precomputed_not_square():
         ValueError, match="Expected precomputed `X` to be square"
     ):
         model.fit(X)
+
+
+def test_get_feature_names_out():
+    X, _ = make_blobs(n_features=5, random_state=42)
+    model = SpectralEmbedding(n_components=2).fit(X)
+    res = model.get_feature_names_out()
+    sol = np.array(["spectralembedding0", "spectralembedding1"], dtype=object)
+    np.testing.assert_array_equal(res, sol)

--- a/python/cuml/tests/test_target_encoder.py
+++ b/python/cuml/tests/test_target_encoder.py
@@ -1,4 +1,4 @@
-# SPDX-FileCopyrightText: Copyright (c) 2019-2026, NVIDIA CORPORATION.
+# SPDX-FileCopyrightText: Copyright (c) 2019-2026, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
 # SPDX-License-Identifier: Apache-2.0
 
 import cudf
@@ -321,3 +321,18 @@ def test_target_encoder_target_type_and_classes():
     enc = TargetEncoder().fit(X, y)
     assert enc.target_type_ == "continuous"
     assert enc.classes_ is None
+
+
+def test_get_feature_names_out():
+    X = np.array([[0, 1], [1, 2], [2, 3]])
+    y = np.array(["a", "b", "a"], dtype="object")
+
+    model = TargetEncoder(multi_feature_mode="combination").fit(X, y)
+    res = model.get_feature_names_out()
+    sol = np.array(["targetencoder0"], dtype=object)
+    np.testing.assert_array_equal(res, sol)
+
+    model = TargetEncoder(multi_feature_mode="independent").fit(X, y)
+    res = model.get_feature_names_out(["a", "b"])
+    sol = np.array(["a", "b"], dtype=object)
+    np.testing.assert_array_equal(res, sol)

--- a/python/cuml/tests/test_tsne.py
+++ b/python/cuml/tests/test_tsne.py
@@ -454,3 +454,11 @@ def test_tsne_n_iter(algorithm):
     model = TSNE(n_components=2, random_state=42).fit(X)
     assert model.n_iter_ > 0
     assert model.n_iter_ <= model.max_iter
+
+
+def test_get_feature_names_out():
+    X, _ = make_blobs(n_features=5, random_state=42)
+    model = TSNE(n_components=2).fit(X)
+    res = model.get_feature_names_out()
+    sol = np.array(["tsne0", "tsne1"], dtype=object)
+    np.testing.assert_array_equal(res, sol)


### PR DESCRIPTION
This adds `get_feature_names_out` support to (almost) all remaining transformers. Only 2 locations remain unaddressed:

- `FunctionTransformer`: this requires a new API addition (and a general cleanup of this transformer), and is outside the scope of this issue. I'll create a dedicated issue to track this.
- `TfidfTransformer`/`TfidfVectorizer`: these estimators need cleanup work (#7317) before the api can be added. This will be handled in a follow-up PR. 

Follow up to #8500. Fixes #8499.