### PR TITLE
Only coerce 1 column 2D outputs to Series for `predict*`/`fit_predict` methods

### DIFF
--- a/python/cuml/cuml/datasets/regression.pyx
+++ b/python/cuml/cuml/datasets/regression.pyx
@@ -128,13 +128,13 @@ def make_regression(
 
     Returns
     -------
-    X : device array of shape [n_samples, n_features]
+    X : array of shape (n_samples, n_features)
         The input samples.
 
-    y : device array of shape [n_samples, n_targets]
+    y : array of shape (n_samples,) or (n_samples, n_targets)
         The output values.
 
-    coef : device array of shape [n_features, n_targets], optional
+    coef : array of shape (n_features,) or (n_features, n_targets), optional
         The coefficient of the underlying linear model. It is returned only if
         coef is True.
     """  # noqa: E501
@@ -183,6 +183,8 @@ def make_regression(
 
     if n_targets == 1:
         y = y.ravel()
+        if coef:
+            coefs = coefs.ravel()
 
     if coef:
         return X, y, coefs

--- a/python/cuml/cuml/datasets/regression.pyx
+++ b/python/cuml/cuml/datasets/regression.pyx
@@ -128,10 +128,10 @@ def make_regression(
 
     Returns
     -------
-    out : device array of shape [n_samples, n_features]
+    X : device array of shape [n_samples, n_features]
         The input samples.
 
-    values : device array of shape [n_samples, n_targets]
+    y : device array of shape [n_samples, n_targets]
         The output values.
 
     coef : device array of shape [n_features, n_targets], optional
@@ -148,11 +148,11 @@ def make_regression(
     handle = get_handle()
     cdef handle_t* handle_ = <handle_t*><size_t>handle.getHandle()
 
-    out = cp.zeros((n_samples, n_features), dtype=dtype, order='C')
-    cdef uintptr_t out_ptr = out.data.ptr
+    X = cp.zeros((n_samples, n_features), dtype=dtype, order='C')
+    cdef uintptr_t out_ptr = X.data.ptr
 
-    values = cp.zeros((n_samples, n_targets), dtype=dtype, order='C')
-    cdef uintptr_t values_ptr = values.data.ptr
+    y = cp.zeros((n_samples, n_targets), dtype=dtype, order='C')
+    cdef uintptr_t values_ptr = y.data.ptr
 
     cdef uintptr_t coef_ptr
     coef_ptr = <uintptr_t> NULL
@@ -181,7 +181,10 @@ def make_regression(
                             <double> tail_strength, <double> noise,
                             <bool> shuffle, <uint64_t> random_state)
 
+    if n_targets == 1:
+        y = y.ravel()
+
     if coef:
-        return out, values, coefs
+        return X, y, coefs
     else:
-        return out, values
+        return X, y

--- a/python/cuml/cuml/internals/outputs.py
+++ b/python/cuml/cuml/internals/outputs.py
@@ -766,6 +766,15 @@ def mlfunc(
 
     sig = inspect.signature(func, follow_wrapped=True)
 
+    # XXX: For legacy reasons, cuml will coerce a 1 column 2D output to a
+    # Series instead of a DataFrame when outputting pandas/cudf types. In the
+    # long run we want to deprecate and remove this (See #7893). However, the
+    # output of `transform`/`fit_transform` should _always_ be a 2D output.
+    # Returning a 1D output from `transform` breaks the sklearn interface and
+    # makes it harder for sklearn to mix with cuml transformers. For now we
+    # disable this coercion for transform outputs.
+    one_col_2d_as_series = func.__name__ not in ("fit_transform", "transform")
+
     # Normalize model_arg to str | None
     if model_arg is ...:
         model_arg = "self" if ("self" in sig.parameters) else None
@@ -844,6 +853,7 @@ def mlfunc(
                     res,
                     output_type,
                     index=index,
+                    one_col_2d_as_series=one_col_2d_as_series,
                 )
 
         return res

--- a/python/cuml/cuml/internals/outputs.py
+++ b/python/cuml/cuml/internals/outputs.py
@@ -768,12 +768,13 @@ def mlfunc(
 
     # XXX: For legacy reasons, cuml will coerce a 1 column 2D output to a
     # Series instead of a DataFrame when outputting pandas/cudf types. In the
-    # long run we want to deprecate and remove this (See #7893). However, the
-    # output of `transform`/`fit_transform` should _always_ be a 2D output.
-    # Returning a 1D output from `transform` breaks the sklearn interface and
-    # makes it harder for sklearn to mix with cuml transformers. For now we
-    # disable this coercion for transform outputs.
-    one_col_2d_as_series = func.__name__ not in ("fit_transform", "transform")
+    # long run we want to deprecate and remove this (See #7893). However, many
+    # methods in sklearn have a defined expectation of whether they return a 1D
+    # or 2D output. For example, `transform` must always return a 2D output,
+    # coercing to a Series breaks the sklearn interface and makes it harder for
+    # sklearn to mix with cuml transformers. For now we restrict this legacy
+    # coercion to only `predict` methods.
+    one_col_2d_as_series = func.__name__.startswith(("predict", "fit_predict"))
 
     # Normalize model_arg to str | None
     if model_arg is ...:

--- a/python/cuml/tests/explainer/test_sampling.py
+++ b/python/cuml/tests/explainer/test_sampling.py
@@ -46,13 +46,15 @@ def test_kmeans_input(input_type):
         cp.testing.assert_array_equal(summary[0], [[1.0, 23.0], [0.0, 52.0]])
         assert isinstance(summary[0], np.ndarray)
     elif input_type == "cudf-series":
-        cp.testing.assert_array_equal(summary[0].values.tolist(), [23.0, 52.0])
-        assert isinstance(summary[0], cudf.Series)
+        cp.testing.assert_array_equal(
+            summary[0].to_numpy().ravel(), [23.0, 52.0]
+        )
+        assert isinstance(summary[0], cudf.DataFrame)
     elif input_type == "pandas-series" and not cudf_pandas_active:
         cp.testing.assert_array_equal(
             summary[0].to_numpy().flatten(), [23.0, 52.0]
         )
-        assert isinstance(summary[0], pd.Series)
+        assert isinstance(summary[0], pd.DataFrame)
     elif input_type == "cupy":
         cp.testing.assert_array_equal(
             summary[0].tolist(), [[1.0, 23.0], [0.0, 52.0]]

--- a/python/cuml/tests/explainer/test_sampling.py
+++ b/python/cuml/tests/explainer/test_sampling.py
@@ -46,14 +46,10 @@ def test_kmeans_input(input_type):
         cp.testing.assert_array_equal(summary[0], [[1.0, 23.0], [0.0, 52.0]])
         assert isinstance(summary[0], np.ndarray)
     elif input_type == "cudf-series":
-        cp.testing.assert_array_equal(
-            summary[0].to_numpy().ravel(), [23.0, 52.0]
-        )
+        cp.testing.assert_array_equal(summary[0].to_numpy(), [[23.0], [52.0]])
         assert isinstance(summary[0], cudf.DataFrame)
     elif input_type == "pandas-series" and not cudf_pandas_active:
-        cp.testing.assert_array_equal(
-            summary[0].to_numpy().flatten(), [23.0, 52.0]
-        )
+        cp.testing.assert_array_equal(summary[0].to_numpy(), [[23.0], [52.0]])
         assert isinstance(summary[0], pd.DataFrame)
     elif input_type == "cupy":
         cp.testing.assert_array_equal(

--- a/python/cuml/tests/test_make_regression.py
+++ b/python/cuml/tests/test_make_regression.py
@@ -1,4 +1,4 @@
-# SPDX-FileCopyrightText: Copyright (c) 2019-2025, NVIDIA CORPORATION.
+# SPDX-FileCopyrightText: Copyright (c) 2019-2026, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
 # SPDX-License-Identifier: Apache-2.0
 #
 
@@ -64,12 +64,16 @@ def test_make_regression(
     )
 
     if coef:
-        out, values, coefs = result
+        X, y, coefs = result
     else:
-        out, values = result
+        X, y = result
 
-    assert out.shape == (n_samples, n_features), "out shape mismatch"
-    assert values.shape == (n_samples, n_targets), "values shape mismatch"
+    assert X.shape == (n_samples, n_features)
+
+    if n_targets == 1:
+        assert y.shape == (n_samples,)
+    else:
+        assert y.shape == (n_samples, n_targets)
 
     if coef:
-        assert coefs.shape == (n_features, n_targets), "coefs shape mismatch"
+        assert coefs.shape == (n_features, n_targets)

--- a/python/cuml/tests/test_make_regression.py
+++ b/python/cuml/tests/test_make_regression.py
@@ -76,4 +76,7 @@ def test_make_regression(
         assert y.shape == (n_samples, n_targets)
 
     if coef:
-        assert coefs.shape == (n_features, n_targets)
+        if n_targets == 1:
+            assert coefs.shape == (n_features,)
+        else:
+            assert coefs.shape == (n_features, n_targets)

--- a/python/cuml/tests/test_reflection.py
+++ b/python/cuml/tests/test_reflection.py
@@ -632,13 +632,12 @@ def test_array_like_inputs_treated_as_numpy_by_reflection():
 
 
 @pytest.mark.parametrize("output_type", ["pandas", "cudf"])
-def test_one_col_2d_array_not_coerced_to_series_in_transform(output_type):
+def test_one_col_2d_array_only_coerced_to_series_for_predict(output_type):
     """For legacy reasons, cuml will coerce a 1 column 2D output to a Series
     instead of a DataFrame when outputting pandas/cudf types. In the long run
     we want to deprecate and remove this (See #7893). However, the output of
-    `transform` should _always_ be a 2D output. Here we test that this coercion
-    is skipped for `transform`/`fit_transform`.
-    """
+    `transform`/`inverse_transform`/... should _always_ be a 2D output. Here we
+    test that this coercion is only enabled for `predict*` methods."""
 
     class MyEstimator(Base):
         @mlfunc
@@ -649,10 +648,25 @@ def test_one_col_2d_array_not_coerced_to_series_in_transform(output_type):
         def fit_transform(self, X):
             return cp.ones((X.shape[0], 1))
 
+        @mlfunc
+        def fit_predict(self, X):
+            return cp.ones((X.shape[0], 1))
+
+        @mlfunc
+        def predict(self, X):
+            return cp.ones((X.shape[0], 1))
+
+        @mlfunc
+        def predict_proba(self, X):
+            return cp.ones((X.shape[0], 1))
+
     model = MyEstimator(output_type=output_type)
     X = cp.ones((3, 4))
     assert model.fit_transform(X).ndim == 2
     assert model.transform(X).ndim == 2
+    assert model.fit_predict(X).ndim == 1
+    assert model.predict(X).ndim == 1
+    assert model.predict_proba(X).ndim == 1
 
 
 def test_estimator_method_with_no_array_input():

--- a/python/cuml/tests/test_reflection.py
+++ b/python/cuml/tests/test_reflection.py
@@ -631,6 +631,30 @@ def test_array_like_inputs_treated_as_numpy_by_reflection():
     assert_output_type(model_fit_cupy.example_no_args(), "cupy")
 
 
+@pytest.mark.parametrize("output_type", ["pandas", "cudf"])
+def test_one_col_2d_array_not_coerced_to_series_in_transform(output_type):
+    """For legacy reasons, cuml will coerce a 1 column 2D output to a Series
+    instead of a DataFrame when outputting pandas/cudf types. In the long run
+    we want to deprecate and remove this (See #7893). However, the output of
+    `transform` should _always_ be a 2D output. Here we test that this coercion
+    is skipped for `transform`/`fit_transform`.
+    """
+
+    class MyEstimator(Base):
+        @mlfunc
+        def transform(self, X):
+            return cp.ones((X.shape[0], 1))
+
+        @mlfunc
+        def fit_transform(self, X):
+            return cp.ones((X.shape[0], 1))
+
+    model = MyEstimator(output_type=output_type)
+    X = cp.ones((3, 4))
+    assert model.fit_transform(X).ndim == 2
+    assert model.transform(X).ndim == 2
+
+
 def test_estimator_method_with_no_array_input():
     X = rand_array("numpy", shape=(10, 5))
     model = DummyEstimator().fit(X)

--- a/python/cuml/tests/test_target_encoder.py
+++ b/python/cuml/tests/test_target_encoder.py
@@ -197,6 +197,7 @@ def test_targetencoder_smooth():
     )
     smooths = [0, 1, 2, 10000]
     for smooth, answer in zip(smooths, answers):
+        answer = np.array(answer)[:, None]
         encoder = TargetEncoder(smooth=smooth)
         train_encoded = encoder.fit_transform(train, label)
         assert array_equal(train_encoded, answer)


### PR DESCRIPTION
For legacy reasons, cuml will coerce a 1 column 2D output to a Series instead of a DataFrame when outputting pandas/cudf types. In the long run we want to deprecate and remove this (See #7893).

However, the output of `transform`/`fit_transform`/`inverse_transform`/... should _always_ be a 2D output. Returning a 1D output from `transform` breaks the sklearn interface and makes it harder for sklearn to mix with cuml transformers.

```python
In [1]: import cuml                                                                                                                                                                          
                                                                                                                                                                                  
In [2]: import numpy as np                                                                                                                                                                   
                                                                                                                                                                                             
In [3]: import pandas as pd                                                                                                                                                                  
                                                                                                                                                                                             
In [4]: X = pd.DataFrame({"x": [0.5, 0.6, 0.7]})                                                                                                                                             
                                                                                                                                                                                             
In [5]: y = pd.Series([1.0, 2.0, 3.0])                                                                                                                                                       
                                                                                                                                                                                             
In [6]: from sklearn.pipeline import Pipeline                                                                                                                                                
                                                                                                                                                                                             
In [7]: pipe = Pipeline([("scaler", cuml.preprocessing.StandardScaler()), ("est", cuml.LinearRegression())])                                                                                                                                                                       
                                                                                                                                                                                             
In [8]: pipe.fit(X, y)
---------------------------------------------------------------------------                                                                                                                  
ValueError
...
ValueError: Expected a 2-dimensional container but got <class 'pandas.Series'> instead. Pass a DataFrame containing a single row (i.e. single sample) or a single column (i.e. single feature
) instead.
```

Viewing this behavior as a bug, we disable this coercion for most methods, only leaving it for `predict*`/`fit_predict` (which often treats 1D and 2D-1col the same).

A few reasons I think we should make this change as _breaking_ (rather than part of a deprecation):

- The current behavior is arguably a bug (at least for `transform`/`fit_transform`). `cuml` tries to implement the sklearn interface. The sklearn interface requires `X` to be a 2D array-like. `transform`/`fit_transform` are expected to return 2D array-like values.
- Unlike other inference methods (like `predict`), `transform`/`fit_transform` have ways in sklearn itself to return a dataframe-like output (e.g. `set_output`). We should strive for alignment in this case. Since `predict` lacks such a feature (and can thus never be hit by stock sklearn code) changing the behavior there feels a bit less urgent.
- In _most_ cases the output of `transform` should have multiple columns. It's only in the rare case that a transformer returns a single column array, and usually those are to then be fed into meta-estimators like `ColumnTransformer` where the individual outputs are stitched together into a larger feature matrix. Most estimators will have multiple feature inputs. As such, I expect this to break very little directly user-facing code, but will help our transformers work better with sklearn's compositional estimators (`Pipeline`, `FeatureUnion`, `ColumnTransformer`, ...).

Part of #7893.