### PR TITLE
Remove all decorator usage of `dask.delayed`

### DIFF
--- a/python/cuml/cuml/dask/common/base.py
+++ b/python/cuml/cuml/dask/common/base.py
@@ -163,7 +163,6 @@ class BaseEstimator:
         return self.internal_model
 
     @staticmethod
-    @dask.delayed
     def _get_model_attr(model, name):
         if hasattr(model, name):
             return getattr(model, name)
@@ -211,7 +210,7 @@ class BaseEstimator:
             else:
                 # Otherwise, fetch the attribute from the distributed
                 # model and return it
-                ret_attr = BaseEstimator._get_model_attr(
+                ret_attr = dask.delayed(BaseEstimator._get_model_attr)(
                     internal_model, attr
                 ).compute()
         else:

--- a/python/cuml/cuml/dask/common/dask_arr_utils.py
+++ b/python/cuml/cuml/dask/common/dask_arr_utils.py
@@ -1,4 +1,4 @@
-# SPDX-FileCopyrightText: Copyright (c) 2020-2025, NVIDIA CORPORATION.
+# SPDX-FileCopyrightText: Copyright (c) 2020-2026, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
 # SPDX-License-Identifier: Apache-2.0
 #
 
@@ -91,18 +91,17 @@ def _get_meta(df):
     return ret
 
 
-@dask.delayed
 def _to_cudf(arr):
     if arr.ndim == 2:
         return cudf.DataFrame(arr)
-    elif arr.ndim == 1:
-        return cudf.Series(arr)
+    return cudf.Series(arr)
 
 
 def to_dask_cudf(dask_arr, client=None):
     client = default_client() if client is None else client
 
-    elms = [_to_cudf(dp) for dp in dask_arr.to_delayed().flatten()]
+    func = dask.delayed(_to_cudf)
+    elms = [func(dp) for dp in dask_arr.to_delayed().flatten()]
     dfs = client.compute(elms)
 
     meta = client.submit(_get_meta, dfs[0])

--- a/python/cuml/cuml/dask/naive_bayes/naive_bayes.py
+++ b/python/cuml/cuml/dask/naive_bayes/naive_bayes.py
@@ -14,6 +14,12 @@ from cuml.dask.common.utils import wait_and_raise_from_futures
 from cuml.naive_bayes import MultinomialNB as MNB
 
 
+def _count_accurate_predictions(y_hat, y):
+    y_hat = cp.asarray(y_hat, dtype=y_hat.dtype)
+    y = cp.asarray(y, dtype=y.dtype)
+    return y.shape[0] - cp.count_nonzero(y - y_hat)
+
+
 class MultinomialNB(BaseEstimator, DelayedPredictionMixin):
     """
     Distributed Naive Bayes classifier for multinomial models
@@ -217,17 +223,11 @@ class MultinomialNB(BaseEstimator, DelayedPredictionMixin):
 
         y_hat = self.predict(X)
 
-        @dask.delayed
-        def _count_accurate_predictions(y_hat, y):
-            y_hat = cp.asarray(y_hat, dtype=y_hat.dtype)
-            y = cp.asarray(y, dtype=y.dtype)
-            return y.shape[0] - cp.count_nonzero(y - y_hat)
-
         delayed_parts = zip(y_hat.to_delayed(), y.to_delayed())
 
-        accuracy_parts = [
-            _count_accurate_predictions(*p) for p in delayed_parts
-        ]
+        func = dask.delayed(_count_accurate_predictions)
+
+        accuracy_parts = [func(*p) for p in delayed_parts]
 
         reduced = first(dask.compute(tree_reduce(accuracy_parts)))
 


### PR DESCRIPTION
We've been seeing some odd `cloudpickle` failures periodically in our dask test suite. While I'm not able to fully describe the error, I suspect this is a bug in cloudpickle around serializing `dask.delayed` decorated functions.

In brief:

- A function defined as a top-level function or a `staticmethod` on a top-level class is trivially serializable with `pickle` (no `cloudpickle` needed).
- Closures (functions defined within a function) will require `cloudpickle`. As will functions decorated with `dask.delayed` (since the top-level name no longer _is_ the function but rather a `Delayed` object, breaking default serialization of the nested object).

Previously we could rely on `cloudpickle` to handle both these cases without issue, so preferring the simpler objects was more about efficiency (both time and serialized message size) than about correctness. However, the periodic failures make me suspect a cloudpickle bug. To test this, I'm removing all remaining locations I could find that _might_ trigger this issue. If we see another failure later then we can investigate this more then.

Fixes #8487.