### PR TITLE
Fix incorrect async initialisations

### DIFF
--- a/cpp/src/solver/cd.cuh
+++ b/cpp/src/solver/cd.cuh
@@ -1,5 +1,5 @@
 /*
- * SPDX-FileCopyrightText: Copyright (c) 2018-2026, NVIDIA CORPORATION.
+ * SPDX-FileCopyrightText: Copyright (c) 2018-2026, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
  * SPDX-License-Identifier: Apache-2.0
  */
 
@@ -213,8 +213,9 @@ int cdFit(const raft::handle_t& handle,
   rmm::device_uvector<ConvState<math_t>> convStateBuf(1, stream);
   auto convStateLoc = convStateBuf.data();
 
-  rmm::device_scalar<math_t> cublas_alpha(1.0, stream);
-  rmm::device_scalar<math_t> cublas_beta(0.0, stream);
+  // Passed to gemv in host pointer mode, so cuBLAS reads them during the call.
+  math_t const cublas_alpha = 1.0;
+  math_t const cublas_beta  = 0.0;
 
   int n_iter = 0;
   while (n_iter < epochs) {
@@ -238,19 +239,19 @@ int cdFit(const raft::handle_t& handle,
         handle, n_rows, coef_loc, input_col_loc, 1, residual.data(), 1, stream);
 
       // coef[ci] = dot(X[:, ci], residual[:])
-      raft::linalg::gemv<math_t, true>(handle,
-                                       false,
-                                       1,
-                                       n_rows,
-                                       cublas_alpha.data(),
-                                       input_col_loc,
-                                       1,
-                                       residual.data(),
-                                       1,
-                                       cublas_beta.data(),
-                                       coef_loc,
-                                       1,
-                                       stream);
+      raft::linalg::gemv<math_t, false>(handle,
+                                        false,
+                                        1,
+                                        n_rows,
+                                        &cublas_alpha,
+                                        input_col_loc,
+                                        1,
+                                        residual.data(),
+                                        1,
+                                        &cublas_beta,
+                                        coef_loc,
+                                        1,
+                                        stream);
 
       // Calculate the new coefficient that minimizes f along coordinate line ci
       // coef[ci] = SoftTreshold(dot(X[:, ci], residual[:]), l1_alpha) /  dot(X[:, ci], X[:, ci]))

--- a/cpp/src/tsne/fft_tsne.cuh
+++ b/cpp/src/tsne/fft_tsne.cuh
@@ -131,10 +131,13 @@ std::pair<value_t, value_t> min_max(const value_t* Y, const value_idx n, cudaStr
   rmm::device_scalar<value_t> min_d(stream);
   rmm::device_scalar<value_t> max_d(stream);
 
-  value_t val = std::numeric_limits<value_t>::max();
-  min_d.set_value_async(val, stream);
-  val = std::numeric_limits<value_t>::lowest();
-  max_d.set_value_async(val, stream);
+  // Each copy needs its own host source, alive and unmodified until the stream
+  // is synchronized below, because rmm may defer reading it until the stream
+  // reaches the copy.
+  value_t const min_init = std::numeric_limits<value_t>::max();
+  value_t const max_init = std::numeric_limits<value_t>::lowest();
+  min_d.set_value_async(min_init, stream);
+  max_d.set_value_async(max_init, stream);
 
   auto nthreads = 256;
   auto nblocks  = raft::ceildiv(n, (value_idx)nthreads);

--- a/cpp/src/umap/simpl_set_embed/algo.cuh
+++ b/cpp/src/umap/simpl_set_embed/algo.cuh
@@ -1,5 +1,5 @@
 /*
- * SPDX-FileCopyrightText: Copyright (c) 2019-2026, NVIDIA CORPORATION.
+ * SPDX-FileCopyrightText: Copyright (c) 2019-2026, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
  * SPDX-License-Identifier: Apache-2.0
  */
 
@@ -174,7 +174,8 @@ bool check_outliers(const int* rows, int m, nnz_t nnz, int threshold, cudaStream
   dim3 blk(TPB_X, 1, 1);
   compute_degrees_kernel<<<grid_nnz, blk, 0, stream>>>(rows, nnz, graph_degree_head.data());
 
-  rmm::device_scalar<bool> has_outlier_d(0, stream);  // initialize to 0
+  rmm::device_scalar<bool> has_outlier_d(stream);
+  raft::linalg::zero(has_outlier_d.data(), 1, stream);
 
   dim3 grid_head_n(raft::ceildiv(static_cast<nnz_t>(m), static_cast<nnz_t>(TPB_X)), 1, 1);
   check_threshold_kernel<<<grid_head_n, blk, 0, stream>>>(


### PR DESCRIPTION
These three locations involve a RMM API that is async, this means the values need to be kept alive until the stream is sync'ed.

The fix was created by AI. From looking at when the failures started appearing in the nightly CI it looked like github.com/rapidsai/rmm/pull/2511 was a candidate for the failures we see. Reading https://github.com/rapidsai/rmm/issues/2521 makes me think these APIs were always used incorrectly by cuml, but the implementation on the inside was not taking full advantage of all the async'ness that it could. Hence we didn't see this until now.

This is also what the AI came up with and it had a plausible explanation of why this explains the failures. For example in this snippet the value in `val` is changed before `set_value_async` has used it.

```c++
value_t val = std::numeric_limits<value_t>::max();
min_d.set_value_async(val, stream);          // deferred read
val = std::numeric_limits<value_t>::lowest(); // val overwritten before the copy runs
max_d.set_value_async(val, stream);
```

The fix in `cd.cuh` makes sense as well. The fix in `algo.cuh` looks sensible, but I'd have to do a bit more thinking to be able to explain why/what it exactly does. I'm inclined to believe my friend AI on this though.

AI also had to do quite a lot of trickery (for a novice like me) to reproduce this issue locally on a non GB300. Which makes some amount of sense given we don't see this for jobs that don't use GB300. I can share the snippet it came up with in order to reproduce this locally. Not sure it is that useful.

Fixes part of #8510
Closes #8509 #8508

(I couldn't come up wit ha good title for this PR :( )