### PR TITLE
CI Use the CUDA sticky errors plugin for cuml.accel tests

### DIFF
--- a/python/cuml/cuml/testing/plugins/restart_corrupted_xdist_worker.py
+++ b/python/cuml/cuml/testing/plugins/restart_corrupted_xdist_worker.py
@@ -6,9 +6,9 @@
 """Keep a poisoned CUDA context from failing every later test in a worker.
 
 Load this from any test suite that runs under pytest-xdist by adding
-``pytest_plugins = "cuml.testing.plugins.sticky_cuda_errors"`` to its
-``conftest.py``. Suites in sibling directories do not share a ``conftest.py``,
-so each one has to register the plugin itself.
+``pytest_plugins = "cuml.testing.plugins.restart_corrupted_xdist_worker"`` to
+its ``conftest.py``. Suites in sibling directories do not share a
+``conftest.py``, so each one has to register the plugin itself.
 """
 
 import os

--- a/python/cuml/cuml/testing/plugins/sticky_cuda_errors.py
+++ b/python/cuml/cuml/testing/plugins/sticky_cuda_errors.py
@@ -1,0 +1,45 @@
+#
+# SPDX-FileCopyrightText: Copyright (c) 2026, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+#
+
+"""Keep a poisoned CUDA context from failing every later test in a worker.
+
+Load this from any test suite that runs under pytest-xdist by adding
+``pytest_plugins = "cuml.testing.plugins.sticky_cuda_errors"`` to its
+``conftest.py``. Suites in sibling directories do not share a ``conftest.py``,
+so each one has to register the plugin itself.
+"""
+
+import os
+
+import cupy as cp
+import pytest
+
+IS_XDIST_WORKER = os.environ.get("PYTEST_XDIST_WORKER") is not None
+
+
+@pytest.hookimpl(trylast=True)
+def pytest_runtest_logreport(report):
+    """Some CUDA errors are "sticky" and cause subsequent CUDA calls in a
+    process to error.
+
+    When running under pytest-xdist, this hook checks for sticky errors on
+    failed tests, and if present will crash the worker after reporting the
+    failure. pytest-xdist will then start a new worker with a clean CUDA
+    context, avoiding sticky errors.
+
+    This hook is a no-op when run outside of pytest-xdist.
+    """
+    if not IS_XDIST_WORKER:
+        return
+
+    # Only check on failed test runs, not other events
+    if report.when == "call" and report.failed:
+        try:
+            # Try allocating a tiny array to invoke a CUDA API. If this fails,
+            # then the context is definitely corrupted.
+            cp.ones(1)
+        except Exception:
+            # Hardcrash the worker
+            os._exit(1)

--- a/python/cuml/cuml_accel_tests/conftest.py
+++ b/python/cuml/cuml_accel_tests/conftest.py
@@ -13,7 +13,7 @@ import pytest
 from cuml.accel import install
 from cuml.accel.core import logger
 
-pytest_plugins = "cuml.testing.plugins.sticky_cuda_errors"
+pytest_plugins = "cuml.testing.plugins.restart_corrupted_xdist_worker"
 
 # Install the accelerator
 install()

--- a/python/cuml/cuml_accel_tests/conftest.py
+++ b/python/cuml/cuml_accel_tests/conftest.py
@@ -1,4 +1,4 @@
-# SPDX-FileCopyrightText: Copyright (c) 2025-2026, NVIDIA CORPORATION.
+# SPDX-FileCopyrightText: Copyright (c) 2025-2026, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
 # SPDX-License-Identifier: Apache-2.0
 
 """Configure ``cuml.accel`` for its integration tests.
@@ -12,6 +12,8 @@ import pytest
 
 from cuml.accel import install
 from cuml.accel.core import logger
+
+pytest_plugins = "cuml.testing.plugins.sticky_cuda_errors"
 
 # Install the accelerator
 install()

--- a/python/cuml/tests/conftest.py
+++ b/python/cuml/tests/conftest.py
@@ -1,5 +1,5 @@
 #
-# SPDX-FileCopyrightText: Copyright (c) 2018-2026, NVIDIA CORPORATION.
+# SPDX-FileCopyrightText: Copyright (c) 2018-2026, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
 # SPDX-License-Identifier: Apache-2.0
 #
 
@@ -49,7 +49,10 @@ def _set_cuda_cache_path_per_xdist_worker(config):
 # =============================================================================
 
 # Add the import here for any plugins that should be loaded EVERY TIME
-pytest_plugins = "cuml.testing.plugins.quick_run_plugin"
+pytest_plugins = [
+    "cuml.testing.plugins.quick_run_plugin",
+    "cuml.testing.plugins.sticky_cuda_errors",
+]
 
 
 # =============================================================================
@@ -63,7 +66,6 @@ HYPOTHESIS_ENABLED = os.environ.get("HYPOTHESIS_ENABLED") in (
     "true",
     "1",
 )
-IS_XDIST_WORKER = os.environ.get("PYTEST_XDIST_WORKER") is not None
 
 
 # =============================================================================
@@ -347,32 +349,6 @@ def _get_gpu_memory(device_index=0):
         return ceil(pynvml.nvmlDeviceGetMemoryInfo(handle).total / 2**30)
     except pynvml.NVMLError_NotSupported:
         return None
-
-
-@pytest.hookimpl(trylast=True)
-def pytest_runtest_logreport(report):
-    """Some CUDA errors are "sticky" and cause subsequent CUDA calls in a
-    process to error.
-
-    When running under pytest-xdist, this hook checks for sticky errors on
-    failed tests, and if present will crash the worker after reporting the
-    failure. pytest-xdist will then start a new worker with a clean CUDA
-    context, avoiding sticky errors.
-
-    This hook is a no-op when run outside of pytest-xdist.
-    """
-    if not IS_XDIST_WORKER:
-        return
-
-    # Only check on failed test runs, not other events
-    if report.when == "call" and report.failed:
-        try:
-            # Try allocating a tiny array to invoke a CUDA API. If this fails,
-            # then the context is definitely corrupted.
-            cp.ones(1)
-        except Exception:
-            # Hardcrash the worker
-            os._exit(1)
 
 
 # =============================================================================

--- a/python/cuml/tests/conftest.py
+++ b/python/cuml/tests/conftest.py
@@ -51,7 +51,7 @@ def _set_cuda_cache_path_per_xdist_worker(config):
 # Add the import here for any plugins that should be loaded EVERY TIME
 pytest_plugins = [
     "cuml.testing.plugins.quick_run_plugin",
-    "cuml.testing.plugins.sticky_cuda_errors",
+    "cuml.testing.plugins.restart_corrupted_xdist_worker",
 ]
 
 


### PR DESCRIPTION
In https://github.com/NVIDIA/cuml/actions/runs/32707368663/job/97371258132 we have cascading errors related to CUDA context poisoning. It turns out this is a separate pytest run (of cuml.accel tests) and didn't already use our "sticky CUDA errors" plugin. This PR moves the plugin so that we can reference it from the two pytest runs.

Without the plugin we get cascading CUDA errors which makes it a bit tedious to look at the log and creates the impression that a lot more is failing than in reality.

For my education: Why do we only check after a failed test instead of after every test? Thinking about async copies etc made me wonder if it can happen that a test poisons the context but does not itself fail. The next test will then fail and might lead to people looking at the wrong test.

xref https://github.com/NVIDIA/cuml/issues/8510