### PR TITLE
CI Mark scikit-learn example as xfail due to upstream bug

### DIFF
--- a/python/cuml/cuml_accel_tests/upstream/scikit-learn/xfail-examples.yaml
+++ b/python/cuml/cuml_accel_tests/upstream/scikit-learn/xfail-examples.yaml
@@ -1,3 +1,7 @@
 - reason: Upstream example fails without cuml.accel on this dependency stack
   tests:
   - "applications::wikipedia_principal_eigenvector"
+- reason: Upstream race, unrelated to cuml.accel, see https://github.com/scikit-learn/scikit-learn/issues/34816
+  strict: false
+  tests:
+  - "callbacks::plot_scoring_monitor"

--- a/python/cuml/cuml_accel_tests/upstream/scikit-learn/xfail-examples.yaml
+++ b/python/cuml/cuml_accel_tests/upstream/scikit-learn/xfail-examples.yaml
@@ -2,6 +2,7 @@
   tests:
   - "applications::wikipedia_principal_eigenvector"
 - reason: Upstream race, unrelated to cuml.accel, see https://github.com/scikit-learn/scikit-learn/issues/34816
+  condition: scikit-learn==1.9.0
   strict: false
   tests:
   - "callbacks::plot_scoring_monitor"


### PR DESCRIPTION
The scikit-learn example sometimes fails (about 80% of the time) with Python 3.14.7. That version of Python introduced a stricter check which catches what I think is a bug in the callback infrastructure of scikit-learn.

xref https://github.com/scikit-learn/scikit-learn/issues/34816