### PR TITLE
pre-commit: update 'cython-lint' to 0.21.1

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -27,7 +27,7 @@ repos:
         args: ["--settings-path", "python/cuml/pyproject.toml"]
         exclude: ^python/.*/_thirdparty/
   - repo: https://github.com/MarcoGorelli/cython-lint
-    rev: v0.16.6
+    rev: v0.21.1
     hooks:
       - id: cython-lint
   - repo: https://github.com/pre-commit/mirrors-clang-format

--- a/python/cuml/cuml/common/opg_data_utils_mg.pyx
+++ b/python/cuml/cuml/common/opg_data_utils_mg.pyx
@@ -1,5 +1,5 @@
 #
-# SPDX-FileCopyrightText: Copyright (c) 2020-2026, NVIDIA CORPORATION.
+# SPDX-FileCopyrightText: Copyright (c) 2020-2026, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
 # SPDX-License-Identifier: Apache-2.0
 #
 import numpy as np
@@ -98,7 +98,7 @@ def build_rank_size_pair(parts_to_sizes):
     """
     cdef vector[RankSizePair*] *rsp_vec = new vector[RankSizePair*]()
 
-    for idx, (rank, size) in enumerate(parts_to_sizes):
+    for (rank, size) in parts_to_sizes:
         rsp_vec.push_back(new RankSizePair(rank, size))
 
     return <uintptr_t>rsp_vec

--- a/python/cuml/cuml/explainer/base.pyx
+++ b/python/cuml/cuml/explainer/base.pyx
@@ -227,7 +227,7 @@ class SHAPBase():
         # model is a multidimensional-output function
         shap_values = []
 
-        for _i in range(self.model_dimensions):
+        for _ in range(self.model_dimensions):
             shap_values.append(cp.zeros(X.shape, dtype=self.dtype))
 
         # Allocate synthetic dataset array once for multiple explanations
@@ -322,7 +322,7 @@ class SHAPBase():
         """
 
         main_effects = []
-        for _idx, x in enumerate(X):
+        for x in X:
             main_effects.append(self._calculate_main_effects(x))
 
         return main_effects

--- a/python/cuml/cuml/explainer/base.pyx
+++ b/python/cuml/cuml/explainer/base.pyx
@@ -1,5 +1,5 @@
 #
-# SPDX-FileCopyrightText: Copyright (c) 2020-2026, NVIDIA CORPORATION.
+# SPDX-FileCopyrightText: Copyright (c) 2020-2026, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
 # SPDX-License-Identifier: Apache-2.0
 #
 import cudf
@@ -227,7 +227,7 @@ class SHAPBase():
         # model is a multidimensional-output function
         shap_values = []
 
-        for i in range(self.model_dimensions):
+        for _i in range(self.model_dimensions):
             shap_values.append(cp.zeros(X.shape, dtype=self.dtype))
 
         # Allocate synthetic dataset array once for multiple explanations
@@ -322,7 +322,7 @@ class SHAPBase():
         """
 
         main_effects = []
-        for idx, x in enumerate(X):
+        for _idx, x in enumerate(X):
             main_effects.append(self._calculate_main_effects(x))
 
         return main_effects

--- a/python/cuml/cuml/neighbors/kneighbors_classifier_mg.pyx
+++ b/python/cuml/cuml/neighbors/kneighbors_classifier_mg.pyx
@@ -107,7 +107,7 @@ class KNeighborsClassifierMG(NearestNeighborsMG):
         )
         cdef int* ptr = <int*><uintptr_t>uniq_labels_d.data.ptr
         cdef vector[int*] uniq_labels_vec
-        for i in range(uniq_labels_d.shape[0]):
+        for _i in range(uniq_labels_d.shape[0]):
             uniq_labels_vec.push_back(<int*>ptr)
             ptr += <int>uniq_labels_d.shape[1]
 
@@ -209,7 +209,7 @@ class KNeighborsClassifierMG(NearestNeighborsMG):
         )
         cdef int* ptr = <int*><uintptr_t>uniq_labels_d.data.ptr
         cdef vector[int*] uniq_labels_vec
-        for i in range(uniq_labels_d.shape[0]):
+        for _i in range(uniq_labels_d.shape[0]):
             uniq_labels_vec.push_back(<int*>ptr)
             ptr += <int>uniq_labels_d.shape[1]
 
@@ -222,7 +222,7 @@ class KNeighborsClassifierMG(NearestNeighborsMG):
         n_outputs = len(n_unique)
 
         # Build probas output array for native code interfacing
-        outputs = [[] for i in range(n_outputs)]
+        outputs = [[] for _i in range(n_outputs)]
         cdef vector[vector[float*]] probas_local_parts
         probas_local_parts.resize(len(local_query_rows))
         for query_idx, n_rows in enumerate(local_query_rows):

--- a/python/cuml/cuml/neighbors/kneighbors_classifier_mg.pyx
+++ b/python/cuml/cuml/neighbors/kneighbors_classifier_mg.pyx
@@ -107,7 +107,7 @@ class KNeighborsClassifierMG(NearestNeighborsMG):
         )
         cdef int* ptr = <int*><uintptr_t>uniq_labels_d.data.ptr
         cdef vector[int*] uniq_labels_vec
-        for _i in range(uniq_labels_d.shape[0]):
+        for _ in range(uniq_labels_d.shape[0]):
             uniq_labels_vec.push_back(<int*>ptr)
             ptr += <int>uniq_labels_d.shape[1]
 
@@ -209,7 +209,7 @@ class KNeighborsClassifierMG(NearestNeighborsMG):
         )
         cdef int* ptr = <int*><uintptr_t>uniq_labels_d.data.ptr
         cdef vector[int*] uniq_labels_vec
-        for _i in range(uniq_labels_d.shape[0]):
+        for _ in range(uniq_labels_d.shape[0]):
             uniq_labels_vec.push_back(<int*>ptr)
             ptr += <int>uniq_labels_d.shape[1]
 
@@ -222,7 +222,7 @@ class KNeighborsClassifierMG(NearestNeighborsMG):
         n_outputs = len(n_unique)
 
         # Build probas output array for native code interfacing
-        outputs = [[] for _i in range(n_outputs)]
+        outputs = [[] for _ in range(n_outputs)]
         cdef vector[vector[float*]] probas_local_parts
         probas_local_parts.resize(len(local_query_rows))
         for query_idx, n_rows in enumerate(local_query_rows):

--- a/python/cuml/cuml/neighbors/nearest_neighbors_mg.pyx
+++ b/python/cuml/cuml/neighbors/nearest_neighbors_mg.pyx
@@ -52,7 +52,7 @@ def _build_part_inputs(arrays, parts_to_ranks, m, n, local_rank):
         )
 
     cdef vector[RankSizePair*] parts_to_ranks_vec
-    for idx, (rank, size) in enumerate(parts_to_ranks):
+    for (rank, size) in parts_to_ranks:
         parts_to_ranks_vec.push_back(new RankSizePair(rank, size))
 
     cdef PartDescriptor *descriptor = new PartDescriptor(


### PR DESCRIPTION
## Description

Contributes to https://github.com/rapidsai/build-planning/issues/317

Updates `cython-lint` to 0.21.1, which contains a fix for compatibility with Cython 3.3.0+ (see linked issue for details).
