### PR TITLE
build: link cuVS when SVM is the only algorithm selected

### DIFF
--- a/cpp/cmake/modules/ConfigureAlgorithms.cmake
+++ b/cpp/cmake/modules/ConfigureAlgorithms.cmake
@@ -121,6 +121,7 @@ else()
      OR kmeans_algo
      OR knn_algo
      OR metrics_algo
+     OR svm_algo
      OR tsne_algo
      OR umap_algo
   )


### PR DESCRIPTION

`-DCUML_ALGORITHMS=SVM` does not build. SVM's kernel cache includes cuVS
headers directly:

    src/svm/sparse_util.cuh:28:  #include <cuvs/distance/distance.hpp>
    src/svm/kernelcache.cuh:35:  #include <cuvs/distance/grammian.hpp>

and `SVC` resolves its kernel function through
`cuvs::distance::kernels::KernelFactory`. But `svm_algo` is missing from the
list in `ConfigureAlgorithms.cmake` that turns on `LINK_CUVS`, so
`get_cuvs.cmake` is never included and the cuVS include directories never
reach the compile line:

    FAILED: CMakeFiles/cuml_objs.dir/src/svm/svc.cu.o
    src/svm/sparse_util.cuh:28:10: fatal error: cuvs/distance/distance.hpp:
    No such file or directory

`CUML_ALGORITHMS=ALL` is unaffected: it takes the other branch, which sets
`LINK_CUVS ON` unconditionally. Only subset builds that select SVM without
also selecting one of dbscan/hdbscan/kmeans/knn/metrics/tsne/umap are broken,
which is why this has gone unnoticed.

Verified both directions on the same build tree:

  before:  svc.cu.o compile line contains no -I for cuvs; build fails with
           the error above
  after:   "CPM: Adding package cuvs", the compile line gains
           -I<cuvs>/cpp/include, and src/svm/svc.cu and src/svm/svr.cu
           compile clean