### PR TITLE
Return Euclidean distances from KMeans transform

### DIFF
--- a/python/cuml/cuml/cluster/kmeans.pyx
+++ b/python/cuml/cuml/cluster/kmeans.pyx
@@ -1116,6 +1116,7 @@ class KMeans(
         cdef handle_t* handle_ = <handle_t*><size_t>handle.getHandle()
         cdef lib.KMeansParams params
         _kmeans_init_params(self, params)
+        params.metric = DistanceType.L2SqrtExpanded
 
         cdef bool values_f32 = X.dtype == cp.float32
         cdef bool indices_i32 = _kmeans_indices_i32(n_rows, n_cols)
@@ -1164,8 +1165,7 @@ class KMeans(
                         <double*>out_ptr,
                     )
         handle.sync()
-        # C++/cuVS uses L2Expanded, which is squared Euclidean.
-        return cp.sqrt(out)
+        return out
 
     @generate_docstring(return_values={'name': 'score',
                                        'type': 'float',

--- a/python/cuml/cuml/cluster/kmeans.pyx
+++ b/python/cuml/cuml/cluster/kmeans.pyx
@@ -1164,7 +1164,8 @@ class KMeans(
                         <double*>out_ptr,
                     )
         handle.sync()
-        return out
+        # C++/cuVS uses L2Expanded, which is squared Euclidean.
+        return cp.sqrt(out)
 
     @generate_docstring(return_values={'name': 'score',
                                        'type': 'float',

--- a/python/cuml/cuml_accel_tests/upstream/scikit-learn/xfail-list.yaml
+++ b/python/cuml/cuml_accel_tests/upstream/scikit-learn/xfail-list.yaml
@@ -668,10 +668,6 @@
   marker: cuml_accel_kmeans_callable_init
   tests:
   - "sklearn.cluster.tests.test_k_means::test_kmeans_init_auto_with_initial_centroids[KMeans-<lambda>-default]"
-- reason: cuml.accel deviates in KMeans cluster_centers_ attribute
-  marker: cuml_accel_kmeans_cluster_centers_attribute
-  tests:
-  - "sklearn.cluster.tests.test_k_means::test_transform[42-KMeans]"
 - reason: These tests always pass on some platforms and always fail on others
   marker: cuml_accel_kmeans_differs_on_certain_platforms
   strict: false

--- a/python/cuml/tests/test_kmeans.py
+++ b/python/cuml/tests/test_kmeans.py
@@ -545,6 +545,36 @@ def test_kmeans_device_buffer_samples_host_path(
     assert adjusted_rand_score(dev_labels, host_labels) >= 0.97
 
 
+def test_kmeans_transform_euclidean():
+    """transform should return Euclidean distances, matching sklearn."""
+    X = np.array(
+        [
+            [0.0, 0.0],
+            [1.0, 1.0],
+            [2.0, 2.0],
+            [10.0, 10.0],
+            [11.0, 11.0],
+            [12.0, 12.0],
+        ]
+    )
+    init = np.array([[1.0, 1.0], [11.0, 11.0]])
+    query = np.array([[0.0, 0.0], [10.0, 10.0]])
+
+    cuml_model = cuml.KMeans(
+        n_clusters=2, init=init, n_init=1, output_type="numpy"
+    )
+    cuml_model.fit(X)
+    cu_dist = cuml_model.transform(query)
+
+    sk_model = cluster.KMeans(n_clusters=2, init=init, n_init=1)
+    sk_model.fit(X)
+    sk_dist = sk_model.transform(query)
+
+    expected = np.sqrt(np.array([[2.0, 242.0], [162.0, 2.0]]))
+    np.testing.assert_allclose(cu_dist, expected)
+    np.testing.assert_allclose(cu_dist, sk_dist)
+
+
 def test_get_feature_names_out():
     X, _ = make_blobs(n_features=5)
     cu_model = cuml.KMeans().fit(X)


### PR DESCRIPTION
## Summary
KMeans.transform currently returns squared distances. sklearn returns Euclidean distances.

This change takes the square root of the transform output so the Python API matches sklearn. score is unchanged.

Fixes #8536

## Test plan
Added a regression test against the six point example from the issue.