### PR TITLE
Propagate feature names in `transform`/`fit_transform`/`inverse_transform`

### DIFF
--- a/python/cuml/cuml/_thirdparty/sklearn/preprocessing/_column_transformer.py
+++ b/python/cuml/cuml/_thirdparty/sklearn/preprocessing/_column_transformer.py
@@ -904,7 +904,11 @@ class ColumnTransformer(
         self.fit_transform(X, y=y)
         return self
 
-    @cuml.internals.mlfunc(set_input_type=True)
+    @cuml.internals.mlfunc(
+        set_input_type=True,
+        preserve_index=True,
+        column_names="feature_names_out",
+    )
     def fit_transform(self, X, y=None):
         """Fit all transformers, transform the data and concatenate results.
 
@@ -956,7 +960,7 @@ class ColumnTransformer(
 
         return self._hstack(list(Xs))
 
-    @cuml.internals.mlfunc
+    @cuml.internals.mlfunc(preserve_index=True, column_names="feature_names_out")
     def transform(self, X):
         """Transform X separately by each transformer, concatenate results.
 

--- a/python/cuml/cuml/_thirdparty/sklearn/preprocessing/_data.py
+++ b/python/cuml/cuml/_thirdparty/sklearn/preprocessing/_data.py
@@ -411,7 +411,7 @@ class MinMaxScaler(
         self.data_range_ = data_range
         return self
 
-    @mlfunc
+    @mlfunc(preserve_index=True, column_names="feature_names_out")
     def transform(self, X):
         """Scale features of X according to feature_range.
 
@@ -438,7 +438,7 @@ class MinMaxScaler(
 
         return X
 
-    @mlfunc
+    @mlfunc(preserve_index=True, column_names="feature_names_in")
     def inverse_transform(self, X):
         """Undo the scaling of X according to feature_range.
 
@@ -866,7 +866,7 @@ class StandardScaler(
 
         return self
 
-    @mlfunc
+    @mlfunc(preserve_index=True, column_names="feature_names_out")
     def transform(self, X, copy=None):
         """Perform standardization by centering and scaling
 
@@ -906,7 +906,7 @@ class StandardScaler(
 
         return X
 
-    @mlfunc
+    @mlfunc(preserve_index=True, column_names="feature_names_in")
     def inverse_transform(self, X, copy=None):
         """Scale back the data to the original representation
 
@@ -1103,7 +1103,7 @@ class MaxAbsScaler(
         self.scale_ = _handle_zeros_in_scale(max_abs)
         return self
 
-    @mlfunc
+    @mlfunc(preserve_index=True, column_names="feature_names_out")
     def transform(self, X):
         """Scale the data
 
@@ -1129,7 +1129,7 @@ class MaxAbsScaler(
 
         return X
 
-    @mlfunc
+    @mlfunc(preserve_index=True, column_names="feature_names_in")
     def inverse_transform(self, X):
         """Scale back the data to the original representation
 
@@ -1372,7 +1372,7 @@ class RobustScaler(
 
         return self
 
-    @mlfunc
+    @mlfunc(preserve_index=True, column_names="feature_names_out")
     def transform(self, X):
         """Center and scale the data.
 
@@ -1401,7 +1401,7 @@ class RobustScaler(
                 X /= self.scale_
         return X
 
-    @mlfunc
+    @mlfunc(preserve_index=True, column_names="feature_names_in")
     def inverse_transform(self, X):
         """Scale back the data to the original representation
 
@@ -1663,7 +1663,7 @@ class PolynomialFeatures(
         self.n_output_features_ = sum(1 for _ in combinations)
         return self
 
-    @mlfunc
+    @mlfunc(preserve_index=True, column_names="feature_names_out")
     def transform(self, X):
         """Transform data to polynomial features
 
@@ -1962,7 +1962,7 @@ class Normalizer(
         check_inputs(self, X, accept_sparse="csr", reset=True)
         return self
 
-    @mlfunc
+    @mlfunc(preserve_index=True, column_names="feature_names_out")
     def transform(self, X, copy=None):
         """Scale each non zero row of X to unit norm
 
@@ -2100,7 +2100,7 @@ class Binarizer(
         check_inputs(self, X, accept_sparse=['csr', 'csc'], reset=True)
         return self
 
-    @mlfunc
+    @mlfunc(preserve_index=True, column_names="feature_names_out")
     def transform(self, X, copy=None):
         """Binarize each element of X
 
@@ -2265,7 +2265,7 @@ class KernelCenterer(
         self.K_fit_all_ = self.K_fit_rows_.sum() / n_samples
         return self
 
-    @mlfunc
+    @mlfunc(preserve_index=True, column_names="feature_names_out")
     def transform(self, K, copy=True):
         """Center kernel matrix.
 
@@ -2677,7 +2677,7 @@ class QuantileTransformer(
 
         return X
 
-    @mlfunc
+    @mlfunc(preserve_index=True, column_names="feature_names_out")
     def transform(self, X):
         """Feature-wise transformation of the data.
 
@@ -2699,7 +2699,7 @@ class QuantileTransformer(
 
         return self._transform(X, inverse=False)
 
-    @mlfunc
+    @mlfunc(preserve_index=True, column_names="feature_names_in")
     def inverse_transform(self, X):
         """Back-projection to the original space.
 
@@ -2950,7 +2950,11 @@ class PowerTransformer(
         self._fit(X, y=y, force_transform=False)
         return self
 
-    @mlfunc(set_input_type=True)
+    @mlfunc(
+        set_input_type=True,
+        preserve_index=True,
+        column_names="feature_names_out",
+    )
     def fit_transform(self, X, y=None):
         return self._fit(X, y, force_transform=True)
 
@@ -2989,7 +2993,7 @@ class PowerTransformer(
 
         return X
 
-    @mlfunc
+    @mlfunc(preserve_index=True, column_names="feature_names_out")
     def transform(self, X):
         """Apply the power transform to each feature using the fitted lambdas.
 
@@ -3024,7 +3028,7 @@ class PowerTransformer(
 
         return X
 
-    @mlfunc
+    @mlfunc(preserve_index=True, column_names="feature_names_in")
     def inverse_transform(self, X):
         """Apply the inverse power transformation using the fitted lambdas.
 

--- a/python/cuml/cuml/_thirdparty/sklearn/preprocessing/_discretization.py
+++ b/python/cuml/cuml/_thirdparty/sklearn/preprocessing/_discretization.py
@@ -297,7 +297,7 @@ class KBinsDiscretizer(TransformerMixin, BaseEstimator, SparseInputTagMixin):
             )
         return n_bins
 
-    @mlfunc
+    @mlfunc(preserve_index=True, column_names="feature_names_out")
     def transform(self, X):
         """
         Discretize the data.
@@ -328,7 +328,7 @@ class KBinsDiscretizer(TransformerMixin, BaseEstimator, SparseInputTagMixin):
         Xt = self._encoder.transform(Xt)
         return Xt
 
-    @mlfunc
+    @mlfunc(preserve_index=True, column_names="feature_names_in")
     def inverse_transform(self, Xt):
         """
         Transform discretized data back to original feature space.

--- a/python/cuml/cuml/_thirdparty/sklearn/preprocessing/_function_transformer.py
+++ b/python/cuml/cuml/_thirdparty/sklearn/preprocessing/_function_transformer.py
@@ -116,7 +116,7 @@ class FunctionTransformer(TransformerMixin, BaseEstimator):
             self._check_inverse_transform(X)
         return self
 
-    @mlfunc
+    @mlfunc(preserve_index=True, column_names="feature_names_out")
     def transform(self, X):
         """Transform X using the forward function.
 
@@ -132,7 +132,7 @@ class FunctionTransformer(TransformerMixin, BaseEstimator):
         """
         return self._transform(X, func=self.func, kw_args=self.kw_args)
 
-    @mlfunc
+    @mlfunc(preserve_index=True, column_names="feature_names_in")
     def inverse_transform(self, X):
         """Transform X using the inverse function.
 

--- a/python/cuml/cuml/_thirdparty/sklearn/preprocessing/_imputation.py
+++ b/python/cuml/cuml/_thirdparty/sklearn/preprocessing/_imputation.py
@@ -429,7 +429,7 @@ class SimpleImputer(SparseInputTagMixin, AllowNaNTagMixin,
         elif strategy == "constant":
             return np.full(X.shape[1], fill_value, dtype=X.dtype)
 
-    @mlfunc
+    @mlfunc(preserve_index=True, column_names="feature_names_out")
     def transform(self, X):
         """Impute all missing values in X.
 
@@ -745,7 +745,7 @@ class MissingIndicator(AllowNaNTagMixin,
 
         return self
 
-    @mlfunc
+    @mlfunc(preserve_index=True, column_names="feature_names_out")
     def transform(self, X):
         """Generate missing values indicator for X.
 
@@ -810,7 +810,11 @@ class MissingIndicator(AllowNaNTagMixin,
             dtype=object,
         )
 
-    @mlfunc(set_input_type=True)
+    @mlfunc(
+        set_input_type=True,
+        preserve_index=True,
+        column_names="feature_names_out",
+    )
     def fit_transform(self, X, y=None):
         """Generate missing values indicator for X.
 

--- a/python/cuml/cuml/cluster/kmeans.pyx
+++ b/python/cuml/cuml/cluster/kmeans.pyx
@@ -1075,7 +1075,7 @@ class KMeans(
                                        'type': 'dense',
                                        'description': 'Transformed data',
                                        'shape': '(n_samples, n_clusters)'})
-    @mlfunc(preserve_index=True)
+    @mlfunc(preserve_index=True, column_names="feature_names_out")
     def transform(self, X):
         """
         Transform X to a cluster-distance space.
@@ -1185,7 +1185,7 @@ class KMeans(
                                        'type': 'dense',
                                        'description': 'Transformed data',
                                        'shape': '(n_samples, n_clusters)'})
-    @mlfunc(preserve_index=True)
+    @mlfunc(preserve_index=True, column_names="feature_names_out")
     def fit_transform(self, X, y=None, sample_weight=None):
         """
         Compute clustering and transform X to cluster-distance space.

--- a/python/cuml/cuml/decomposition/incremental_pca.py
+++ b/python/cuml/cuml/decomposition/incremental_pca.py
@@ -387,7 +387,7 @@ class IncrementalPCA(PCA):
 
         return self
 
-    @mlfunc(preserve_index=True)
+    @mlfunc(preserve_index=True, column_names="feature_names_out")
     def transform(self, X):
         """
         Apply dimensionality reduction to X.

--- a/python/cuml/cuml/decomposition/pca.pyx
+++ b/python/cuml/cuml/decomposition/pca.pyx
@@ -503,7 +503,11 @@ class PCA(InteropMixin,
                                        'type': 'dense_sparse',
                                        'description': 'Transformed values',
                                        'shape': '(n_samples, n_components)'})
-    @mlfunc(set_input_type=True, preserve_index=True)
+    @mlfunc(
+        set_input_type=True,
+        preserve_index=True,
+        column_names="feature_names_out",
+    )
     def fit_transform(self, X, y=None):
         """
         Fit the model with X and apply the dimensionality reduction on X.
@@ -572,7 +576,7 @@ class PCA(InteropMixin,
                                        'type': 'dense_sparse',
                                        'description': 'Transformed values',
                                        'shape': '(n_samples, n_features)'})
-    @mlfunc(preserve_index=True)
+    @mlfunc(preserve_index=True, column_names="feature_names_in")
     def inverse_transform(
         self,
         X,
@@ -664,7 +668,7 @@ class PCA(InteropMixin,
                                        'type': 'dense_sparse',
                                        'description': 'Transformed values',
                                        'shape': '(n_samples, n_components)'})
-    @mlfunc(preserve_index=True)
+    @mlfunc(preserve_index=True, column_names="feature_names_out")
     def transform(self, X):
         """
         Apply dimensionality reduction to X.

--- a/python/cuml/cuml/decomposition/tsvd.pyx
+++ b/python/cuml/cuml/decomposition/tsvd.pyx
@@ -299,7 +299,11 @@ class TruncatedSVD(InteropMixin,
                                        'type': 'dense',
                                        'description': 'Reduced version of X',
                                        'shape': '(n_samples, n_components)'})
-    @mlfunc(set_input_type=True, preserve_index=True)
+    @mlfunc(
+        set_input_type=True,
+        preserve_index=True,
+        column_names="feature_names_out",
+    )
     def fit_transform(self, X, y=None):
         """
         Fit model to X and perform dimensionality reduction on X.
@@ -396,7 +400,7 @@ class TruncatedSVD(InteropMixin,
                                        'type': 'dense',
                                        'description': 'X in original space',
                                        'shape': '(n_samples, n_features)'})
-    @mlfunc(preserve_index=True)
+    @mlfunc(preserve_index=True, column_names="feature_names_in")
     def inverse_transform(self, X):
         """
         Transform X back to its original space.
@@ -458,7 +462,7 @@ class TruncatedSVD(InteropMixin,
                                        'type': 'dense',
                                        'description': 'Reduced version of X',
                                        'shape': '(n_samples, n_components)'})
-    @mlfunc(preserve_index=True)
+    @mlfunc(preserve_index=True, column_names="feature_names_out")
     def transform(self, X):
         """
         Perform dimensionality reduction on X.

--- a/python/cuml/cuml/internals/outputs.py
+++ b/python/cuml/cuml/internals/outputs.py
@@ -697,6 +697,7 @@ def mlfunc(
     convert_output=True,
     set_input_type=False,
     preserve_index=False,
+    column_names=None,
 ):
     """A decorator for enabling common `cuml` machinery on a function/method.
 
@@ -753,6 +754,11 @@ def mlfunc(
         Whether to preserve the index of the ``array_arg`` argument (if any)
         in the function output. This should typically be set to ``True`` on
         any inference (predict/transform-like) methods.
+    column_names : {"features_names_in", "features_names_out", None}, default=None
+        Where to get the column names from when outputting a DataFrame. Options
+        are ``None`` (for default column names), ``"features_names_in"`` (to
+        use ``model.feature_names_in_``) or ``"features_names_out"`` (to
+        determine feature names from ``get_feature_names_out``.
     """
     if func is None:
         return lambda func: mlfunc(
@@ -762,6 +768,7 @@ def mlfunc(
             convert_output=convert_output,
             preserve_index=preserve_index,
             set_input_type=set_input_type,
+            column_names=column_names,
         )
 
     sig = inspect.signature(func, follow_wrapped=True)
@@ -803,6 +810,13 @@ def mlfunc(
     if preserve_index and array_arg is None:
         raise ValueError(
             "`preserve_index=True` is not valid with `array_arg=None`"
+        )
+
+    if column_names not in ("feature_names_in", "feature_names_out", None):
+        raise ValueError(f"`{column_names=}` is not valid")
+    elif column_names is not None and model_arg is None:
+        raise ValueError(
+            f"`{column_names=}` is not valid with `model_arg=None`"
         )
 
     @functools.wraps(func)
@@ -856,6 +870,14 @@ def mlfunc(
                     index=index,
                     one_col_2d_as_series=one_col_2d_as_series,
                 )
+
+                if output_type in ("cudf", "pandas"):
+                    if column_names == "feature_names_in":
+                        if hasattr(model, "feature_names_in_"):
+                            res.columns = model.feature_names_in_
+                    elif column_names == "feature_names_out":
+                        if hasattr(model, "get_feature_names_out"):
+                            res.columns = model.get_feature_names_out()
 
         return res
 

--- a/python/cuml/cuml/internals/outputs.py
+++ b/python/cuml/cuml/internals/outputs.py
@@ -754,10 +754,10 @@ def mlfunc(
         Whether to preserve the index of the ``array_arg`` argument (if any)
         in the function output. This should typically be set to ``True`` on
         any inference (predict/transform-like) methods.
-    column_names : {"features_names_in", "features_names_out", None}, default=None
+    column_names : {"feature_names_in", "feature_names_out", None}, default=None
         Where to get the column names from when outputting a DataFrame. Options
-        are ``None`` (for default column names), ``"features_names_in"`` (to
-        use ``model.feature_names_in_``) or ``"features_names_out"`` (to
+        are ``None`` (for default column names), ``"feature_names_in"`` (to
+        use ``model.feature_names_in_``) or ``"feature_names_out"`` (to
         determine feature names from ``get_feature_names_out``.
     """
     if func is None:
@@ -871,13 +871,23 @@ def mlfunc(
                     one_col_2d_as_series=one_col_2d_as_series,
                 )
 
-                if output_type in ("cudf", "pandas"):
+                if isinstance(res, (cudf.DataFrame, pd.DataFrame)):
                     if column_names == "feature_names_in":
-                        if hasattr(model, "feature_names_in_"):
-                            res.columns = model.feature_names_in_
+                        cols = getattr(model, "feature_names_in_", None)
                     elif column_names == "feature_names_out":
-                        if hasattr(model, "get_feature_names_out"):
-                            res.columns = model.get_feature_names_out()
+                        try:
+                            cols = model.get_feature_names_out()
+                        except AttributeError:
+                            # Can happen if no `get_feature_names_out` method
+                            # exists, or in meta-estimators (like
+                            # ColumnTransformer) where the sub-estimator
+                            # doesn't support `get_feature_names_out`.
+                            cols = None
+                    else:
+                        cols = None
+
+                    if cols is not None:
+                        res.columns = cols
 
         return res
 

--- a/python/cuml/cuml/manifold/spectral_embedding.pyx
+++ b/python/cuml/cuml/manifold/spectral_embedding.pyx
@@ -186,7 +186,7 @@ class SpectralEmbedding(
         # Exposed to support sklearn's `get_feature_names_out`
         return self.embedding_.shape[1]
 
-    @mlfunc(preserve_index=True)
+    @mlfunc(preserve_index=True, column_names="feature_names_out")
     def fit_transform(self, X, y=None):
         """Fit the model from data in X and transform X.
 

--- a/python/cuml/cuml/manifold/t_sne.pyx
+++ b/python/cuml/cuml/manifold/t_sne.pyx
@@ -682,7 +682,7 @@ class TSNE(InteropMixin,
                                                        data in \
                                                        low-dimensional space.',
                                        'shape': '(n_samples, n_components)'})
-    @mlfunc(preserve_index=True)
+    @mlfunc(preserve_index=True, column_names="feature_names_out")
     def fit_transform(self, X, y=None, *, knn_graph=None):
         """
         Fit X into an embedded space and return that transformed output.

--- a/python/cuml/cuml/manifold/umap/umap.pyx
+++ b/python/cuml/cuml/manifold/umap/umap.pyx
@@ -1434,7 +1434,7 @@ class UMAP(
             "shape": "(n_samples, n_components)"
         }
     )
-    @mlfunc(preserve_index=True)
+    @mlfunc(preserve_index=True, column_names="feature_names_out")
     def fit_transform(self, X, y=None, *, knn_graph=None):
         """
         Fit X into an embedded space and return that transformed
@@ -1467,7 +1467,7 @@ class UMAP(
             "shape": "(n_samples, n_components)"
         }
     )
-    @mlfunc(preserve_index=True)
+    @mlfunc(preserve_index=True, column_names="feature_names_out")
     def transform(self, X):
         """
         Transform X into the existing embedded space and return that
@@ -1592,7 +1592,7 @@ class UMAP(
             "shape": "(n_samples, n_features)"
         }
     )
-    @mlfunc(preserve_index=True)
+    @mlfunc(preserve_index=True, column_names="feature_names_in")
     def inverse_transform(self, X):
         """Transform X in the existing embedded space back into the input
         data space and return that transformed output.

--- a/python/cuml/cuml/preprocessing/_target_encoder.py
+++ b/python/cuml/cuml/preprocessing/_target_encoder.py
@@ -228,7 +228,7 @@ class TargetEncoder(InteropMixin, Base):
         self.train = train
         return self
 
-    @mlfunc(preserve_index=True)
+    @mlfunc(preserve_index=True, column_names="feature_names_out")
     def fit_transform(self, X, y, *, fold_ids=None):
         """
         Simultaneously fit and transform an input
@@ -277,7 +277,7 @@ class TargetEncoder(InteropMixin, Base):
             return input_features
         return np.asarray(["targetencoder0"], dtype=object)
 
-    @mlfunc(preserve_index=True)
+    @mlfunc(preserve_index=True, column_names="feature_names_out")
     def transform(self, X):
         """
         Transform an input into its categorical keys.

--- a/python/cuml/cuml/preprocessing/encoders.py
+++ b/python/cuml/cuml/preprocessing/encoders.py
@@ -384,7 +384,11 @@ class OneHotEncoder(DeprecatedGetFeatureNamesMixin, InteropMixin, Base):
         X = check_cudf(X, input_name="X")
         return self._fit(X)
 
-    @mlfunc(set_input_type=True, preserve_index=True)
+    @mlfunc(
+        set_input_type=True,
+        preserve_index=True,
+        column_names="feature_names_out",
+    )
     @generate_docstring(
         y=None,
         return_values={
@@ -474,7 +478,7 @@ class OneHotEncoder(DeprecatedGetFeatureNamesMixin, InteropMixin, Base):
 
         return self
 
-    @mlfunc(preserve_index=True)
+    @mlfunc(preserve_index=True, column_names="feature_names_out")
     @generate_docstring(
         return_values={
             "name": "X_out",
@@ -569,7 +573,7 @@ class OneHotEncoder(DeprecatedGetFeatureNamesMixin, InteropMixin, Base):
             return out
         return out.toarray()
 
-    @mlfunc(preserve_index=True)
+    @mlfunc(preserve_index=True, column_names="feature_names_in")
     def inverse_transform(self, X):
         """Convert the data back to the original representation.
 
@@ -639,9 +643,6 @@ class OneHotEncoder(DeprecatedGetFeatureNamesMixin, InteropMixin, Base):
 
         for idx, mask in found_unknown.items():
             out.loc[mask, idx] = None
-
-        if getattr(self, "feature_names_in_", None) is not None:
-            out.columns = self.feature_names_in_
 
         return out
 
@@ -779,7 +780,11 @@ class OrdinalEncoder(OneToOneFeatureMixin, Base):
         X = check_cudf(X, input_name="X")
         return self._fit(X)
 
-    @mlfunc(set_input_type=True, preserve_index=True)
+    @mlfunc(
+        set_input_type=True,
+        preserve_index=True,
+        column_names="feature_names_out",
+    )
     @generate_docstring(
         y=None,
         return_values={
@@ -825,7 +830,7 @@ class OrdinalEncoder(OneToOneFeatureMixin, Base):
 
         return self
 
-    @mlfunc(preserve_index=True)
+    @mlfunc(preserve_index=True, column_names="feature_names_out")
     @generate_docstring(
         return_values={
             "name": "X_out",
@@ -872,7 +877,7 @@ class OrdinalEncoder(OneToOneFeatureMixin, Base):
 
         return out
 
-    @mlfunc(preserve_index=True)
+    @mlfunc(preserve_index=True, column_names="feature_names_in")
     def inverse_transform(self, X):
         """Convert the data back to the original representation.
 
@@ -928,8 +933,5 @@ class OrdinalEncoder(OneToOneFeatureMixin, Base):
 
         for idx, mask in found_unknown.items():
             out.loc[mask, idx] = None
-
-        if getattr(self, "feature_names_in_", None) is not None:
-            out.columns = self.feature_names_in_
 
         return out

--- a/python/cuml/cuml/random_projection/random_projection.py
+++ b/python/cuml/cuml/random_projection/random_projection.py
@@ -130,7 +130,7 @@ class _BaseRandomProjection(
         return self
 
     @generate_docstring()
-    @mlfunc(preserve_index=True)
+    @mlfunc(preserve_index=True, column_names="feature_names_out")
     def transform(self, X):
         """Project the data by taking the matrix product with the random matrix."""
         check_is_fitted(self)
@@ -159,7 +159,7 @@ class _BaseRandomProjection(
         return out
 
     @generate_docstring()
-    @mlfunc(preserve_index=True)
+    @mlfunc(preserve_index=True, column_names="feature_names_out")
     def fit_transform(self, X, y=None):
         """Fit to data, then transform it."""
         return self.fit(X).transform(X)

--- a/python/cuml/tests/test_reflection.py
+++ b/python/cuml/tests/test_reflection.py
@@ -560,8 +560,16 @@ def test_mlfunc_column_names(input_type):
             self.fit(X)
             return cp.ones((X.shape[0], self._n_features_out))
 
+        @mlfunc(column_names="feature_names_out")
+        def returns_sparse_matrix(self, X):
+            return cupyx.scipy.sparse.eye(
+                X.shape[0],
+                self._n_features_out,
+                format="csr",
+            )
+
         @mlfunc
-        def other(self, X):
+        def no_names(self, X):
             return cp.ones((X.shape[0], self.n_features_in_))
 
         @mlfunc(column_names="feature_names_in")
@@ -577,8 +585,12 @@ def test_mlfunc_column_names(input_type):
     np.testing.assert_array_equal(X2.columns, X.columns)
 
     # column_names=None doesn't add anything
-    res = model.other(X)
+    res = model.no_names(X)
     np.testing.assert_array_equal(res.columns, [0, 1])
+
+    # No error applying names if not a dataframe output
+    res = model.returns_sparse_matrix(X)
+    assert cupyx.scipy.sparse.issparse(res) or scipy.sparse.issparse(res)
 
     # Works if no feature names
     X = X.to_numpy()

--- a/python/cuml/tests/test_reflection.py
+++ b/python/cuml/tests/test_reflection.py
@@ -10,6 +10,7 @@ import numpy as np
 import pandas as pd
 import pytest
 import scipy.sparse
+from sklearn.base import ClassNamePrefixFeaturesOutMixin
 
 import cuml
 from cuml.internals.base import Base
@@ -540,6 +541,53 @@ def test_mlfunc_preserve_index(input_type, output_type):
     cudf.testing.assert_series_equal(
         cudf.Series(res), cudf.Series([2, 3, 4], index=df.index)
     )
+
+
+@pytest.mark.parametrize("input_type", ["pandas", "cudf"])
+def test_mlfunc_column_names(input_type):
+    xdf = cudf if input_type == "cudf" else pd
+    X = xdf.DataFrame({"x": [1, 2, 3], "y": [4, 5, 6]})
+
+    class MyEstimator(ClassNamePrefixFeaturesOutMixin, Base):
+        @mlfunc(set_input_type=True)
+        def fit(self, X):
+            X = check_inputs(self, X, reset=True)
+            self._n_features_out = X.shape[1] * 2
+            return self
+
+        @mlfunc(column_names="feature_names_out")
+        def fit_transform(self, X):
+            self.fit(X)
+            return cp.ones((X.shape[0], self._n_features_out))
+
+        @mlfunc
+        def other(self, X):
+            return cp.ones((X.shape[0], self.n_features_in_))
+
+        @mlfunc(column_names="feature_names_in")
+        def inverse_transform(self, X):
+            return cp.ones((X.shape[0], self.n_features_in_))
+
+    # Works with feature names
+    model = MyEstimator()
+    Xt = model.fit_transform(X)
+    np.testing.assert_array_equal(Xt.columns, model.get_feature_names_out())
+
+    X2 = model.inverse_transform(Xt)
+    np.testing.assert_array_equal(X2.columns, X.columns)
+
+    # column_names=None doesn't add anything
+    res = model.other(X)
+    np.testing.assert_array_equal(res.columns, [0, 1])
+
+    # Works if no feature names
+    X = X.to_numpy()
+    model = MyEstimator(output_type=input_type)
+    Xt = model.fit_transform(X)
+    np.testing.assert_array_equal(Xt.columns, model.get_feature_names_out())
+
+    X2 = model.inverse_transform(Xt)
+    np.testing.assert_array_equal(X2.columns, [0, 1])
 
 
 @pytest.mark.parametrize("dtype", ["int32", "object", "U"])

--- a/python/cuml/tests/test_sklearn_compatibility.py
+++ b/python/cuml/tests/test_sklearn_compatibility.py
@@ -2,8 +2,12 @@
 # SPDX-FileCopyrightText: Copyright (c) 2024-2026, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
 # SPDX-License-Identifier: Apache-2.0
 #
-
+import numpy as np
+import pandas as pd
 import pytest
+import sklearn
+from sklearn.datasets import make_blobs
+from sklearn.metrics.pairwise import linear_kernel
 from sklearn.utils import estimator_checks
 
 from cuml.cluster import (
@@ -345,7 +349,7 @@ GET_FEATURE_NAMES_OUT_ESTIMATORS = [
     OneHotEncoder(),
     OrdinalEncoder(),
     PolynomialFeatures(),
-    KBinsDiscretizer(),
+    KBinsDiscretizer(encode="onehot-dense"),
     ColumnTransformer(transformers=[("trans1", PolynomialFeatures(), [0, 1])]),
     SimpleImputer(),
     MissingIndicator(),
@@ -404,3 +408,70 @@ def test_sklearn_get_feature_names_out_all_estimators_covered():
         f"Estimators implementing `get_feature_names_out` that aren't tested or "
         f"excluded: {', '.join(sorted(c.__name__ for c in uncovered))}"
     )
+
+
+@pytest.mark.parametrize(
+    "transformer",
+    GET_FEATURE_NAMES_OUT_ESTIMATORS,
+    ids=lambda est: type(est).__name__,
+)
+def test_transform_inverse_transform_set_index_and_column_names(transformer):
+    """Check that `index` and `columns` are properly set on results of:
+
+    - `fit_transform`
+    - `transform`
+    - `inverse_transform`
+
+    when outputting dataframe objects.
+    """
+    transformer = sklearn.clone(transformer)
+    if hasattr(transformer, "sparse_output"):
+        transformer.sparse_output = False
+    if hasattr(transformer, "random_state"):
+        transformer.random_state = 42
+
+    tags = transformer.__sklearn_tags__()
+
+    X, y = make_blobs(
+        n_samples=30,
+        centers=[[0, 0, 0], [1, 1, 1]],
+        random_state=0,
+        n_features=2,
+        cluster_std=0.1,
+    )
+    X -= X.mean(axis=0)
+    if tags.input_tags.categorical:
+        X = np.round((X - X.min()))
+    elif tags.input_tags.positive_only:
+        X = X - X.min()
+    elif tags.input_tags.pairwise:
+        X = linear_kernel(X, X)
+
+    X = pd.DataFrame(
+        X,
+        columns=[f"C{i}" for i in range(X.shape[1])],
+        index=np.arange(X.shape[0]) * 10,
+    )
+    Xt = None
+
+    if hasattr(transformer, "transform"):
+        Xt = transformer.fit(X, y=y).transform(X)
+        np.testing.assert_array_equal(
+            Xt.columns, transformer.get_feature_names_out()
+        )
+        np.testing.assert_array_equal(Xt.index, X.index)
+    if hasattr(transformer, "fit_transform"):
+        Xt = transformer.fit_transform(X, y=y)
+        np.testing.assert_array_equal(
+            Xt.columns, transformer.get_feature_names_out()
+        )
+        np.testing.assert_array_equal(Xt.index, X.index)
+
+    assert Xt is not None, (
+        "Estimator must implement `transform` and/or `fit_transform"
+    )
+
+    if hasattr(transformer, "inverse_transform"):
+        X2 = transformer.inverse_transform(Xt)
+        np.testing.assert_array_equal(X2.columns, X.columns)
+        np.testing.assert_array_equal(X2.index, X.index)


### PR DESCRIPTION
This:

- Adds a new `column_names` option to `mlfunc` for configuring how column names are attached to reflected outputs when outputting a `DataFrame`. This may be one of:
  - `None`: uses the default numeric column names. This is the default behavior.
  - `"feature_names_out"`: uses the output of `model.get_feature_names_out()` as column names. This should be used for all `transform`/`fit_transform` methods.
  - `"feature_names_in"`: uses `feature_names_in_` as column names. This should be used for all `inverse_transform` methods.
- Applies `column_names` and `preserve_index` consistently across all transformers (excluding `cuml.feature_extraction`, which still needs #7317 first).
- Adds a generic test to ensure this behavior is applied to our transformers consistently.

Fixes #5564.
Fixes #4036.
Fixes #8513.
Precursor for #5645.