### PR TITLE
Make `cupy.ndarray` pickle patch version conditional

### DIFF
--- a/python/cuml/cuml/__init__.py
+++ b/python/cuml/cuml/__init__.py
@@ -80,18 +80,19 @@ def _setup_cupy():
     import copyreg
 
     import cupy as cp
+    from packaging.version import Version
     from rmm.allocators.cupy import rmm_cupy_allocator
 
     # Enable rmm_cupy_allocator
     cp.cuda.set_allocator(rmm_cupy_allocator)
 
     # TODO: this is a workaround for https://github.com/cupy/cupy/issues/10084
-    # It can be conditionally done once the cupy fix is out (see
-    # https://github.com/rapidsai/cuml/issues/8364).
-    copyreg.dispatch_table[cp.ndarray] = lambda x: (
-        cp.array,
-        (x.get(order="A"),),
-    )
+    # This can be removed once we require cupy >= 14.2.0
+    if Version(cp.__version__) < Version("14.2.0"):
+        copyreg.dispatch_table[cp.ndarray] = lambda x: (
+            cp.array,
+            (x.get(order="A"),),
+        )
 
 
 _setup_cupy()


### PR DESCRIPTION
The bug in pickling `cupy.ndarray` objects was fixed in cupy version 14.2.0. Here we make the patch fixing this bug conditional on the cupy version, and note when the patch may be removed entirely.

Fixes #8364.