### PR TITLE
`OneHotEncoder` fallback to CPU on bytes inputs

### DIFF
--- a/docs/source/cuml-accel/compatibility.rst
+++ b/docs/source/cuml-accel/compatibility.rst
@@ -497,6 +497,7 @@ sklearn.preprocessing
 
    ``OneHotEncoder`` will fall back to CPU in the following cases:
 
+   - If any columns in ``X`` have ``bytes`` values (``str`` values work fine).
    - If ``dtype`` is not a float or bool dtype.
    - If ``drop`` is ``"if_binary"``
    - If ``handle_unknown`` is ``"warn"`` or ``"infrequent_if_exist"``.
@@ -508,9 +509,6 @@ sklearn.preprocessing
 
    - cuML's encoder treats ``None`` and ``NaN`` values as identical, while
      scikit-learn's encoder treats these as different categories.
-
-   - cuML's encoder doesn't support numpy's bytes dtype (e.g. ``"S10"``) as
-     inputs and will error if encountered.
 
 
 .. dropdown:: ``TargetEncoder``

--- a/python/cuml/cuml/accel/_overrides/sklearn/preprocessing.py
+++ b/python/cuml/cuml/accel/_overrides/sklearn/preprocessing.py
@@ -11,6 +11,7 @@ from cuml.accel.estimator_proxy import (
     classproperty,
 )
 from cuml.internals.interop import UnsupportedOnGPU
+from cuml.internals.validation import check_cudf
 
 __all__ = (
     "StandardScaler",
@@ -56,10 +57,27 @@ class PolynomialFeatures(ArrayAPIProxyBase):
         return model.get_params(deep=False)
 
 
+def _check_onehotencoder_X(X):
+    """Check if inputs are supported on GPU"""
+    try:
+        return check_cudf(X, input_name="X")
+    except TypeError as exc:
+        if str(exc).startswith("X with bytes dtype"):
+            raise UnsupportedOnGPU(
+                "X with bytes dtype is not supported"
+            ) from None
+        raise
+
+
 class OneHotEncoder(ProxyBase):
     _gpu_class = cuml.preprocessing.OneHotEncoder
 
+    def _gpu_fit(self, X, y=None):
+        X = _check_onehotencoder_X(X)
+        return self._gpu.fit(X, y=y)
+
     def _gpu_fit_transform(self, X, y=None, **fit_params):
+        X = _check_onehotencoder_X(X)
         return self._gpu.fit_transform(X, y=y, **fit_params)
 
 

--- a/python/cuml/cuml/internals/validation.py
+++ b/python/cuml/cuml/internals/validation.py
@@ -962,48 +962,64 @@ def check_cudf(
     # automatically upcast here to float32.
     # XXX: hardcode `nan_as_null=True` (cudf's default) so the behavior
     # doesn't switch when cudf.pandas is active.
-    if isinstance(array, pd.Series):
-        if array.dtype == "float16":
-            array = array.astype("float32")
-        array = cudf.Series(array, nan_as_null=True)
-    elif isinstance(array, pd.DataFrame):
-        f16_cols = array.select_dtypes("float16").columns.tolist()
-        if f16_cols:
-            array = array.astype({c: "float32" for c in f16_cols})
-        array = cudf.DataFrame(array, nan_as_null=True)
-
     if not isinstance(array, (cudf.DataFrame, cudf.Series)):
-        # Normalize to numpy or cupy array with minimal copying
-        if hasattr(array, "__cuda_array_interface__"):
-            array = cp.asarray(array)
-        elif hasattr(array, "__array__") or hasattr(
-            array, "__array_interface__"
-        ):
-            array = np.asarray(array)
-        elif not isinstance(array, np.ndarray):
-            array = np.asarray(array, dtype=object)
+        array_dtype_kind = None
+        if isinstance(array, pd.Series):
+            if array.dtype == "float16":
+                array = array.astype("float32")
+        elif isinstance(array, pd.DataFrame):
+            f16_cols = array.select_dtypes("float16").columns.tolist()
+            if f16_cols:
+                array = array.astype({c: "float32" for c in f16_cols})
+        else:
+            # Normalize to numpy or cupy array with minimal copying
+            if hasattr(array, "__cuda_array_interface__"):
+                array = cp.asarray(array)
+            elif hasattr(array, "__array__") or hasattr(
+                array, "__array_interface__"
+            ):
+                array = np.asarray(array)
+            elif not isinstance(array, np.ndarray):
+                array = np.asarray(array, dtype=object)
 
-        if array.dtype.kind == "c":
-            raise ValueError("Complex data not supported")
+            if array.dtype.kind == "c":
+                raise ValueError("Complex data not supported")
 
-        if array.dtype == "float16":
-            array = array.astype("float32")
+            if array.dtype == "float16":
+                array = array.astype("float32")
+            array_dtype_kind = array.dtype.kind
 
         array_shape = array.shape
         cls = cudf.DataFrame if array.ndim == 2 else cudf.Series
-        if array.dtype == "object":
+        if array_dtype_kind == "O":
             # For object dtype inputs, coerce back to list (cheap) to rely on
             # cudf's per-column dtype inference. On failure raise an error
             # compatible with what sklearn's `check_dtype_object` expects.
-            try:
-                array = cls(array.tolist(), nan_as_null=True)
-            except Exception as exc:
-                raise TypeError(
-                    f"An object dtype {input_name or 'input'} argument must be "
-                    "composed of strings, numbers, booleans, or nulls."
-                ) from exc
-        else:
+            array = array.tolist()
+
+        # Try to coerce to cudf, raising a nicer error message on failure.
+        try:
             array = cls(array, nan_as_null=True)
+        except Exception as exc:
+            # XXX: cudf throws a number of different errors when handed a
+            # container with bytes inputs. Here we try to detect all of them,
+            # falling back to a generic message about mixed object dtypes.
+            needle = None
+            if isinstance(exc, ValueError):
+                needle = "type_id"
+            elif isinstance(
+                exc, (NotImplementedError, cudf.errors.MixedTypeError)
+            ):
+                needle = "bytes"
+            if needle and needle in str(exc).lower():
+                raise TypeError(
+                    f"{input_name or 'Input'} with bytes dtype is not supported. "
+                    "Try converting to strings first."
+                ) from exc
+            raise TypeError(
+                f"An object dtype {input_name or 'input'} argument must be "
+                "composed of strings, numbers, booleans, or nulls."
+            ) from exc
     else:
         array_shape = array.shape
 

--- a/python/cuml/cuml/preprocessing/encoders.py
+++ b/python/cuml/cuml/preprocessing/encoders.py
@@ -333,8 +333,29 @@ class OneHotEncoder(DeprecatedGetFeatureNamesMixin, InteropMixin, Base):
             and model.feature_name_combiner == "concat"
         ):
             raise UnsupportedOnGPU("`feature_name_combiner` is not supported")
+
+        categories = model.categories
+        # Fallback if input categories contain bytes dtypes
+        if not (isinstance(categories, str) and categories == "auto"):
+            for i, c in enumerate(model.categories):
+                if getattr(getattr(c, "dtype", None), "kind", "O") not in "OS":
+                    continue
+                try:
+                    check_cudf(c, ensure_ndim=1)
+                except TypeError as exc:
+                    exc_str = str(exc)
+                    if exc_str.startswith("An object dtype input"):
+                        invalid = "mixed"
+                    elif exc_str.startswith("Input with bytes dtype"):
+                        invalid = "bytes"
+                    else:
+                        raise
+                    raise UnsupportedOnGPU(
+                        f"Category {i} with {invalid} dtype is not supported"
+                    ) from None
+
         return {
-            "categories": model.categories,
+            "categories": categories,
             "drop": model.drop,
             "sparse_output": model.sparse_output,
             "dtype": model.dtype,

--- a/python/cuml/cuml_accel_tests/integration/test_preprocessing.py
+++ b/python/cuml/cuml_accel_tests/integration/test_preprocessing.py
@@ -166,6 +166,47 @@ def test_one_hot_encoder(sparse_output):
     np.testing.assert_array_equal(X, inv_X)
 
 
+@pytest.mark.parametrize(
+    "kind, dtype",
+    [
+        ("list", None),
+        ("numpy", "O"),
+        ("numpy", "S"),
+        ("pandas", "O"),
+        ("pandas", "S"),
+    ],
+)
+@pytest.mark.parametrize("auto", [True, False])
+def test_one_hot_encoder_bytes_inputs(kind, dtype, auto):
+    X = [[b"a", b"x"], [b"b", b"x"], [b"a", b"y"]]
+    if kind == "numpy":
+        X = np.array(X, dtype=dtype)
+    elif kind == "pandas":
+        X = pd.DataFrame(X).astype(dtype)
+
+    if auto:
+        cats = "auto"
+    else:
+        cats = [[b"a", b"b"], [b"x", b"y"]]
+        if kind == "numpy":
+            cats = [np.array(c, dtype=dtype) for c in cats]
+        elif kind == "pandas":
+            cats = [pd.Series(c, dtype=dtype) for c in cats]
+
+    enc = OneHotEncoder(sparse_output=False, categories=cats)
+    if not auto and dtype == "O":
+        # XXX: exception raised by sklearn, we don't really care what it is
+        with pytest.raises(ValueError):
+            enc.fit(X)
+    else:
+        enc.fit(X)
+        np.testing.assert_array_equal(enc.categories_[0], [b"a", b"b"])
+        np.testing.assert_array_equal(enc.categories_[1], [b"x", b"y"])
+        Xt = enc.transform(X)
+        sol = np.array([[1, 0, 1, 0], [0, 1, 1, 0], [1, 0, 0, 1]])
+        np.testing.assert_array_equal(Xt, sol)
+
+
 def test_label_encoder():
     y = np.array(["a", "b", "a", "b"])
     enc = LabelEncoder()

--- a/python/cuml/cuml_accel_tests/upstream/scikit-learn/xfail-list.yaml
+++ b/python/cuml/cuml_accel_tests/upstream/scikit-learn/xfail-list.yaml
@@ -842,30 +842,6 @@
   marker: onehotencoder_design_differences
   tests:
   - "sklearn.preprocessing.tests.test_encoders::test_one_hot_encoder_unsorted_categories"
-- reason: cuml's encoder doesn't support bytes dtypes
-  marker: onehotencoder_design_differences
-  condition: scikit-learn<1.9.0
-  tests:
-  - "sklearn.preprocessing.tests.test_encoders::test_encoders_string_categories[dataframe-S-O]"
-  - "sklearn.preprocessing.tests.test_encoders::test_encoders_string_categories[dataframe-S-S]"
-  - "sklearn.preprocessing.tests.test_encoders::test_encoders_string_categories[dataframe-S-U]"
-- reason: cuml's encoder doesn't support bytes dtypes
-  marker: onehotencoder_design_differences
-  condition: scikit-learn>=1.9.0
-  tests:
-  - "sklearn.preprocessing.tests.test_encoders::test_encoders_string_categories[pandas-S-O]"
-  - "sklearn.preprocessing.tests.test_encoders::test_encoders_string_categories[pandas-S-S]"
-  - "sklearn.preprocessing.tests.test_encoders::test_encoders_string_categories[pandas-S-U]"
-- reason: cuml's encoder doesn't support bytes dtypes
-  marker: onehotencoder_design_differences
-  tests:
-  - "sklearn.preprocessing.tests.test_encoders::test_encoders_string_categories[array-S-O]"
-  - "sklearn.preprocessing.tests.test_encoders::test_encoders_string_categories[array-S-S]"
-  - "sklearn.preprocessing.tests.test_encoders::test_encoders_string_categories[array-S-U]"
-  - "sklearn.preprocessing.tests.test_encoders::test_encoders_string_categories[list-S-O]"
-  - "sklearn.preprocessing.tests.test_encoders::test_encoders_string_categories[list-S-S]"
-  - "sklearn.preprocessing.tests.test_encoders::test_encoders_string_categories[list-S-U]"
-  - "sklearn.preprocessing.tests.test_encoders::test_mixed_string_bytes_categoricals"
 - reason: cuml's encoder may use alternate dtypes to store categories
   marker: onehotencoder_design_differences
   tests:

--- a/python/cuml/tests/test_validation.py
+++ b/python/cuml/tests/test_validation.py
@@ -2200,12 +2200,36 @@ def test_check_cudf_nan_as_null(kind):
     assert res.iloc[:, 1].isin(vals).all()
 
 
+@pytest.mark.parametrize(
+    "kind, dtype",
+    [
+        ("list", None),
+        ("numpy", "O"),
+        ("numpy", "S"),
+        ("pandas", "O"),
+        ("pandas", "S"),
+    ],
+)
+@pytest.mark.parametrize("ndim", [1, 2])
+def test_check_cudf_bytes_dtype_errors(kind, dtype, ndim):
+    X = [b"a", b"b"] if ndim == 1 else [[b"a", b"b"], [b"c", b"d"]]
+    if kind == "numpy":
+        X = np.array(X, dtype=dtype)
+    elif kind == "pandas":
+        X = (pd.DataFrame if ndim == 2 else pd.Series)(X).astype(dtype)
+
+    with pytest.raises(TypeError, match="X with bytes dtype is not supported"):
+        check_cudf(X, ensure_ndim=None, input_name="X")
+
+
 @pytest.mark.parametrize("kind", ["list", "array"])
 def test_check_cudf_unsupported_object_inputs(kind):
-    data = [[{"x": 1}, 1], [1, 2]]
+    X = [[{"x": 1}, 1], [1, 2]]
+    if kind == "array":
+        X = np.array(X, dtype=object)
 
     with pytest.raises(
         TypeError,
         match="An object dtype X argument must be composed of",
     ):
-        check_cudf(data, input_name="X")
+        check_cudf(X, input_name="X")


### PR DESCRIPTION
``sklearn.preprocessing.OneHotEncoder`` supports bytes values in ``X``, while ``cuml.preprocessing.OneHotEncoder`` doesn't. We now fallback to CPU in ``cuml.accel`` for this encoder if any column in the input ``X`` contains ``bytes`` values.

To do this, we change the validation code in `check_cudf` a bit to better detect errors due to bytes inputs. This is a bit tricky since cudf may throw a number of different errors in this case. We've added appropriate tests covering the various cases to ensure no regression.

This also lets us remove a few xfailed tests in the `cuml.accel` upstream test suite, and fixes a regression in running one of the sklearn examples.

Fixes #8547.