### PR TITLE
Include inherited methods in class API docs

### DIFF
--- a/docs/source/_templates/autosummary/base.rst
+++ b/docs/source/_templates/autosummary/base.rst
@@ -16,6 +16,7 @@
 
 .. autoclass:: {{ objname }}
    :members:
+   :inherited-members:
 
 {%- else -%}
 


### PR DESCRIPTION
Previously only methods defined directly on a class were exposed in the docs. Now all public & documented methods on each class are exposed in the docs.

Fixes #6055.