### PR TITLE
Use latest intersphinx inventories on main

### DIFF
--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -210,10 +210,8 @@ texinfo_documents = [
 
 # Example configuration for intersphinx: refer to the Python standard library.
 intersphinx_mapping = {
-    # TODO: Use stable URLs once subpath redirects are available:
-    # https://github.com/rapidsai/build-infra/issues/395
-    # rapids-pre-commit-hooks: disable-next-line
-    "cudf": ("https://docs.nvidia.com/cudf/26.10/", None),
+    # Main consumes the latest published documentation from RAPIDS dependencies.
+    "cudf": ("https://docs.nvidia.com/cudf/latest/", None),
     "numpy": ("https://numpy.org/doc/stable/", None),
     "python": ("https://docs.python.org/3", None),
     # TODO: re-enable once scipy docs are more reliable
@@ -224,8 +222,7 @@ intersphinx_mapping = {
         "https://nvidia.github.io/cuda-python/cuda-core/latest/",
         None,
     ),
-    # rapids-pre-commit-hooks: disable-next-line
-    "rmm": ("https://docs.nvidia.com/rmm/26.10/", None),
+    "rmm": ("https://docs.nvidia.com/rmm/latest/", None),
 }
 
 # Config numpydoc


### PR DESCRIPTION
Points the cuDF and RMM intersphinx mappings at their published `latest` inventories, restoring documentation builds on `main`. The broader release-aware selection remains tracked in #8549.

Closes #8557
