### PR TITLE
Add cuTile build dependencies to CUDA 13.3 pip devcontainers

### DIFF
--- a/dependencies.yaml
+++ b/dependencies.yaml
@@ -46,6 +46,7 @@ files:
       # from source.
       - common_build
       - cuda
+      - cutile_python
       - cuda_version
       - depends_on_cudf
       - depends_on_cuda_python
@@ -457,6 +458,23 @@ dependencies:
               use_cuda_wheels: "true"
             packages:
               - cuda-toolkit==13.3.*
+  cutile_python:
+    specific:
+      - output_types: requirements
+        matrices:
+          - matrix:
+              cuda: "12.*"
+            packages:
+          - matrix:
+              cuda: "13.3"
+            packages:
+              - cuda-tile
+              - cuda-toolkit[tileiras]==13.3.*
+          - matrix:
+              cuda: "13.*"
+            packages:
+              - cuda-tile
+              - cuda-toolkit[tileiras]==13.*
   cuda:
     common:
       - output_types: [conda]


### PR DESCRIPTION
Adds `cuda-tile` and `cuda-toolkit[tileiras]` to the CUDA 13.3 `pip` devcontainer requirements so the current cuVS source-build path can generate its embedded cuTile kernels.

This addresses the CMake configuration failure on both `amd64` and `arm64`; #8520 separately tracks avoiding the cuVS source build.

Closes #8559
