### PR TITLE
Disable public docs features in PR previews

### DIFF
--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -123,7 +123,8 @@ html_theme = "nvidia_sphinx_theme"
 # documentation.
 #
 html_theme_options = {
-    "public_docs_features": os.environ.get("CI") == "true",
+    "public_docs_features": os.environ.get("CI") == "true"
+    and os.environ.get("RAPIDS_BUILD_TYPE") != "pull-request",
     "external_links": [],
     "icon_links": [
         {


### PR DESCRIPTION
Disables `public_docs_features` when `RAPIDS_BUILD_TYPE=pull-request`, while keeping them enabled for nightly and release documentation builds.

Follow-up to https://github.com/NVIDIA/cuml/pull/8533
