### PR TITLE
CI: Use isolated build for all wheel packages

### DIFF
--- a/ci/build_wheel.sh
+++ b/ci/build_wheel.sh
@@ -39,31 +39,30 @@ sccache --stop-server 2>/dev/null || true
 
 rapids-logger "Building '${package_name}' wheel"
 
+build_env_dir="/tmp/${package_name}-wheel-build-env"
+# `build` preserves this environment after a failed build for debugging. CI
+# retries must start with an empty directory, as required by `--env-dir`.
+rm -rf "${build_env_dir}"
+
 RAPIDS_PIP_WHEEL_ARGS=(
-  -w dist
-  -v
-  --no-deps
-  --disable-pip-version-check
+  --wheel
+  --outdir dist
+  --verbose
+  # A fixed location keeps isolated-build include paths stable for sccache.
+  --env-dir "${build_env_dir}"
+  --dependency-constraints-txt "${PIP_CONSTRAINT}"
 )
 
 # Add py-api setting for stable ABI builds
 if [[ "${stable_abi}" == "true" ]] && [[ -n "${RAPIDS_PY_API:-}" ]]; then
-  RAPIDS_PIP_WHEEL_ARGS+=(--config-settings="skbuild.wheel.py-api=${RAPIDS_PY_API}")
+  RAPIDS_PIP_WHEEL_ARGS+=(--config-setting="skbuild.wheel.py-api=${RAPIDS_PY_API}")
 fi
 
-# Only use --build-constraint when build isolation is enabled.
-#
-# Passing '--build-constraint' and '--no-build-isolation` together results in an error from 'pip',
-# but we want to keep environment variable PIP_CONSTRAINT set unconditionally.
-# PIP_NO_BUILD_ISOLATION=0 means "add --no-build-isolation" (ref: https://github.com/pypa/pip/issues/5735)
-if [[ "${PIP_NO_BUILD_ISOLATION:-}" != "0" ]]; then
-    RAPIDS_PIP_WHEEL_ARGS+=(--build-constraint="${PIP_CONSTRAINT}")
-fi
-
-# unset PIP_CONSTRAINT (set by rapids-init-pip)... it doesn't affect builds as of pip 25.3, and
-# results in an error from 'pip wheel' when set and --build-constraint is also passed
+# `build` receives the same generated constraints explicitly. Unset the
+# environment variable so it does not constrain the frontend installation.
 unset PIP_CONSTRAINT
-rapids-pip-retry wheel \
+
+rapids-python-build-retry \
     "${RAPIDS_PIP_WHEEL_ARGS[@]}" \
     .
 

--- a/ci/build_wheel_cuml.sh
+++ b/ci/build_wheel_cuml.sh
@@ -15,7 +15,8 @@ RAPIDS_PY_CUDA_SUFFIX="$(rapids-wheel-ctk-name-gen "${RAPIDS_CUDA_VERSION}")"
 # available for pip to find.
 #
 # env variable 'PIP_CONSTRAINT' is set up by rapids-init-pip. It constrains all subsequent
-# 'pip install', 'pip download', etc. calls (except those used in 'pip wheel', handled separately in build scripts)C
+# 'pip install', 'pip download', etc. calls (except the isolated wheel build,
+# which is handled separately by ci/build_wheel.sh)
 LIBCUML_WHEELHOUSE=$(rapids-download-from-github "$(rapids-artifact-name wheel_cpp libcuml cuml --cuda "$RAPIDS_CUDA_VERSION")")
 echo "libcuml-${RAPIDS_PY_CUDA_SUFFIX} @ file://$(echo "${LIBCUML_WHEELHOUSE}"/libcuml_*.whl)" >> "${PIP_CONSTRAINT}"
 

--- a/ci/build_wheel_libcuml.sh
+++ b/ci/build_wheel_libcuml.sh
@@ -24,10 +24,6 @@ rapids-pip-retry install \
     --prefer-binary \
     -r /tmp/requirements-build.txt
 
-# build with '--no-build-isolation', for better sccache hit rate
-# 0 really means "add --no-build-isolation" (ref: https://github.com/pypa/pip/issues/5735)
-export PIP_NO_BUILD_ISOLATION=0
-
 EXCLUDE_ARGS=(
   --exclude "libcublas.so.*"
   --exclude "libcublasLt.so.*"


### PR DESCRIPTION
Replace pip wheel with isolated python -m build --wheel in the shared wheel-build helper used by every wheel build job