### PR TITLE
Validate HDBSCAN min_cluster_size

### DIFF
--- a/cpp/src/hdbscan/runner.cuh
+++ b/cpp/src/hdbscan/runner.cuh
@@ -165,6 +165,7 @@ void _fit_hdbscan(const raft::handle_t& handle,
 
   int min_cluster_size = params.min_cluster_size;
 
+  RAFT_EXPECTS(min_cluster_size > 1, "min_cluster_size must be greater than one");
   RAFT_EXPECTS(params.min_samples <= m, "min_samples must be at most the number of samples in X");
 
   build_linkage(handle, X, m, n, metric, params, core_dists, out);

--- a/cpp/tests/sg/hdbscan_test.cu
+++ b/cpp/tests/sg/hdbscan_test.cu
@@ -31,6 +31,7 @@
 #include <hdbscan/detail/extract.cuh>
 #include <hdbscan/detail/reachability.cuh>
 
+#include <numeric>
 #include <vector>
 
 namespace ML {
@@ -126,6 +127,52 @@ typedef HDBSCANTest<float, int64_t> HDBSCANTestF_Int;
 TEST_P(HDBSCANTestF_Int, Result) { EXPECT_TRUE(score >= 0.85); }
 
 INSTANTIATE_TEST_CASE_P(HDBSCANTest, HDBSCANTestF_Int, ::testing::ValuesIn(hdbscan_inputsf2));
+
+TEST(HDBSCANTest, RejectsSingletonClusters)
+{
+  raft::handle_t handle;
+  constexpr int64_t n_rows = 64;
+  constexpr int64_t n_cols = 1;
+
+  std::vector<float> data_h(n_rows);
+  std::iota(data_h.begin(), data_h.end(), 0.0f);
+  rmm::device_uvector<float> data(n_rows * n_cols, handle.get_stream());
+  raft::copy(data.data(), data_h.data(), data.size(), handle.get_stream());
+
+  rmm::device_uvector<int64_t> children(n_rows * 2, handle.get_stream());
+  rmm::device_uvector<float> deltas(n_rows, handle.get_stream());
+  rmm::device_uvector<int64_t> sizes(n_rows * 2, handle.get_stream());
+  rmm::device_uvector<int64_t> labels(n_rows, handle.get_stream());
+  rmm::device_uvector<int64_t> mst_src(n_rows - 1, handle.get_stream());
+  rmm::device_uvector<int64_t> mst_dst(n_rows - 1, handle.get_stream());
+  rmm::device_uvector<float> mst_weights(n_rows - 1, handle.get_stream());
+  rmm::device_uvector<float> core_dists(n_rows, handle.get_stream());
+  rmm::device_uvector<float> probabilities(n_rows, handle.get_stream());
+
+  HDBSCAN::Common::hdbscan_output<int64_t, float> out(handle,
+                                                      n_rows,
+                                                      labels.data(),
+                                                      probabilities.data(),
+                                                      children.data(),
+                                                      sizes.data(),
+                                                      deltas.data(),
+                                                      mst_src.data(),
+                                                      mst_dst.data(),
+                                                      mst_weights.data());
+  HDBSCAN::Common::HDBSCANParams params;
+  params.min_samples      = 1;
+  params.min_cluster_size = 1;
+
+  EXPECT_THROW(hdbscan(handle,
+                       data.data(),
+                       n_rows,
+                       n_cols,
+                       ML::distance::DistanceType::L2SqrtExpanded,
+                       params,
+                       out,
+                       core_dists.data()),
+               raft::exception);
+}
 
 template <typename T, typename IdxT>
 class ClusterCondensingTest : public ::testing::TestWithParam<ClusterCondensingInputs<T, IdxT>> {

--- a/python/cuml/cuml/cluster/hdbscan/hdbscan.pyx
+++ b/python/cuml/cuml/cluster/hdbscan/hdbscan.pyx
@@ -525,7 +525,7 @@ class HDBSCAN(InteropMixin, ClusterMixin, CMajorInputTagMixin, Base):
     min_cluster_size : int, optional (default = 5)
         The minimum number of samples in a group for that group to be
         considered a cluster; groupings smaller than this size will be left
-        as noise.
+        as noise. Must be greater than one.
 
     min_samples : int, optional (default=None)
         The number of samples in a neighborhood for a point
@@ -949,6 +949,8 @@ class HDBSCAN(InteropMixin, ClusterMixin, CMajorInputTagMixin, Base):
         self._raw_data_cpu = None
 
         # Validate and prepare hyperparameters
+        if self.min_cluster_size <= 1:
+            raise ValueError("min_cluster_size must be greater than one")
         if (min_samples := self.min_samples) is None:
             min_samples = self.min_cluster_size
         if not (1 <= min_samples <= 1023):

--- a/python/cuml/tests/test_hdbscan.py
+++ b/python/cuml/tests/test_hdbscan.py
@@ -45,6 +45,15 @@ pytestmark = pytest.mark.filterwarnings(
 dataset_names = ["noisy_circles", "noisy_moons", "varied"]
 
 
+def test_hdbscan_rejects_singleton_clusters():
+    X = cp.arange(64, dtype=cp.float32).reshape(-1, 1)
+
+    with pytest.raises(
+        ValueError, match="min_cluster_size must be greater than one"
+    ):
+        HDBSCAN(min_samples=1, min_cluster_size=1).fit(X)
+
+
 def assert_cluster_counts(sk_agg, cuml_agg, digits=25):
     sk_unique, sk_counts = np.unique(sk_agg.labels_, return_counts=True)
     sk_counts = np.sort(sk_counts)


### PR DESCRIPTION
Requires `min_cluster_size` to be greater than one at both the Python and `libcuml` entry points, matching the reference `hdbscan` behavior. Adds regression coverage for both entry points.
