### PR TITLE
fix(deps): remove `rapidsai` from channel resolution to avoid `rapids-xgboost`

### DIFF
--- a/conda/environments/all_cuda-129_arch-aarch64.yaml
+++ b/conda/environments/all_cuda-129_arch-aarch64.yaml
@@ -2,7 +2,6 @@
 # To make changes, edit ../../dependencies.yaml and run `rapids-dependency-file-generator`.
 channels:
 - rapidsai-nightly
-- rapidsai
 - conda-forge
 dependencies:
 - c-compiler

--- a/conda/environments/all_cuda-129_arch-x86_64.yaml
+++ b/conda/environments/all_cuda-129_arch-x86_64.yaml
@@ -2,7 +2,6 @@
 # To make changes, edit ../../dependencies.yaml and run `rapids-dependency-file-generator`.
 channels:
 - rapidsai-nightly
-- rapidsai
 - conda-forge
 dependencies:
 - c-compiler

--- a/conda/environments/all_cuda-133_arch-aarch64.yaml
+++ b/conda/environments/all_cuda-133_arch-aarch64.yaml
@@ -2,7 +2,6 @@
 # To make changes, edit ../../dependencies.yaml and run `rapids-dependency-file-generator`.
 channels:
 - rapidsai-nightly
-- rapidsai
 - conda-forge
 dependencies:
 - c-compiler

--- a/conda/environments/all_cuda-133_arch-x86_64.yaml
+++ b/conda/environments/all_cuda-133_arch-x86_64.yaml
@@ -2,7 +2,6 @@
 # To make changes, edit ../../dependencies.yaml and run `rapids-dependency-file-generator`.
 channels:
 - rapidsai-nightly
-- rapidsai
 - conda-forge
 dependencies:
 - c-compiler

--- a/conda/environments/clang_tidy_cuda-129_arch-x86_64.yaml
+++ b/conda/environments/clang_tidy_cuda-129_arch-x86_64.yaml
@@ -2,7 +2,6 @@
 # To make changes, edit ../../dependencies.yaml and run `rapids-dependency-file-generator`.
 channels:
 - rapidsai-nightly
-- rapidsai
 - conda-forge
 dependencies:
 - c-compiler

--- a/conda/environments/clang_tidy_cuda-133_arch-x86_64.yaml
+++ b/conda/environments/clang_tidy_cuda-133_arch-x86_64.yaml
@@ -2,7 +2,6 @@
 # To make changes, edit ../../dependencies.yaml and run `rapids-dependency-file-generator`.
 channels:
 - rapidsai-nightly
-- rapidsai
 - conda-forge
 dependencies:
 - c-compiler

--- a/conda/environments/cpp_all_cuda-129_arch-x86_64.yaml
+++ b/conda/environments/cpp_all_cuda-129_arch-x86_64.yaml
@@ -2,7 +2,6 @@
 # To make changes, edit ../../dependencies.yaml and run `rapids-dependency-file-generator`.
 channels:
 - rapidsai-nightly
-- rapidsai
 - conda-forge
 dependencies:
 - c-compiler

--- a/conda/environments/cpp_all_cuda-133_arch-x86_64.yaml
+++ b/conda/environments/cpp_all_cuda-133_arch-x86_64.yaml
@@ -2,7 +2,6 @@
 # To make changes, edit ../../dependencies.yaml and run `rapids-dependency-file-generator`.
 channels:
 - rapidsai-nightly
-- rapidsai
 - conda-forge
 dependencies:
 - c-compiler

--- a/dependencies.yaml
+++ b/dependencies.yaml
@@ -286,7 +286,6 @@ files:
       - depends_on_rapids_logger
 channels:
   - rapidsai-nightly
-  - rapidsai
   - conda-forge
 dependencies:
   rapids_build_backend:


### PR DESCRIPTION
We've deprecated `rapids-xgboost`, and in an effort to fix development on `main`, we've removed `rapids-xgboost` from the `rapidsai-nightly` channel.  This was breaking builds on this release branch, but I believe that that breakage is due to strict channel priority trying to pick up packages from the `rapidsai` channel.

So, removing the `rapidsai` channel from the channel list here.  It shouldn't be required for development anyway.
