### PR TITLE
Forward merge release/26.10 into main

### DIFF
--- a/dependencies.yaml
+++ b/dependencies.yaml
@@ -530,7 +530,6 @@ dependencies:
           - ipython
           - ipykernel
           - nbsphinx
-          - numpydoc
           - &onnxruntime onnxruntime
           - recommonmark
           - *scikit_learn
@@ -543,6 +542,7 @@ dependencies:
         packages:
           - doxygen=1.9.1
           - matplotlib-base
+          - numpydoc
           - pip:
               - nvidia-sphinx-theme
       - output_types: requirements
@@ -680,8 +680,6 @@ dependencies:
           - hypothesis>=6.0,<7
           - msgspec
           - nltk
-          # upstream sklearn docstring tests require numpydoc<1.9
-          - numpydoc<1.9
           # 'nvidia-ml-py' provides the 'pynvml' module
           - nvidia-ml-py>=12
           - *onnxruntime
@@ -700,6 +698,10 @@ dependencies:
       - output_types: conda
         packages:
           - cuvs==26.10.*,>=0.0.0a0
+          # upstream sklearn docstring tests require numpydoc<1.9
+          #
+          # 'numpydoc' is intentionally conda-only, see https://github.com/NVIDIA/cuml/issues/7710
+          - numpydoc<1.9
   test_python_accel_sklearn:
     # Exact pin the sklearn versions used for running upstream sklearn tests
     # in cuml.accel. We exact pin here since our xfail list is tightly coupled

--- a/python/cuml/pyproject.toml
+++ b/python/cuml/pyproject.toml
@@ -121,7 +121,6 @@ test = [
     "lightgbm",
     "msgspec",
     "nltk",
-    "numpydoc<1.9",
     "nvidia-ml-py>=12",
     "onnxruntime",
     "pynndescent",

--- a/python/cuml/tests/test_base.py
+++ b/python/cuml/tests/test_base.py
@@ -4,7 +4,6 @@
 import inspect
 
 import numpy as np
-import numpydoc.docscrape
 import pandas as pd
 import pylibraft.common.handle
 import pytest
@@ -54,6 +53,8 @@ def test_base_subclass_init_matches_docs(child_class: str):
             "the base arguments in constructors."
         )
 
+    numpydoc_docscrape = pytest.importorskip("numpydoc.docscrape")
+
     # To quickly find and replace all instances in the documentation, the below
     # regex's may be useful
     # output_type: r"^[ ]{4}output_type :.*\n(^(?![ ]{0,4}(?![ ]{4,})).*(\n))+"
@@ -71,12 +72,12 @@ def test_base_subclass_init_matches_docs(child_class: str):
 
     # Load the base class signature, parse the docstring and pull out params
     base_sig = inspect.signature(cuml.Base, follow_wrapped=True)
-    base_doc = numpydoc.docscrape.NumpyDocString(cuml.Base.__doc__)
+    base_doc = numpydoc_docscrape.NumpyDocString(cuml.Base.__doc__)
     base_doc_params = base_doc["Parameters"]
 
     # Load the current class signature, parse the docstring and pull out params
     klass_sig = inspect.signature(klass, follow_wrapped=True)
-    klass_doc = numpydoc.docscrape.NumpyDocString(klass.__doc__ or "")
+    klass_doc = numpydoc_docscrape.NumpyDocString(klass.__doc__ or "")
     klass_doc_params = klass_doc["Parameters"]
 
     for name, param in base_sig.parameters.items():


### PR DESCRIPTION
Manual no-squash forward merge of `release/26.10` into `main` to unblock the conflicting ops-bot forward-merger.

Follow-up to #8600.

@coderabbitai ignore