### PR TITLE
Exclude libkvikio from libcuml wheel repair

### DIFF
--- a/ci/build_wheel_libcuml.sh
+++ b/ci/build_wheel_libcuml.sh
@@ -36,6 +36,7 @@ EXCLUDE_ARGS=(
   --exclude "libcusolver.so.*"
   --exclude "libcusparse.so.*"
   --exclude "libcuvs.so"
+  --exclude "libkvikio.so"
   --exclude "libnvforest.so"
   --exclude "libnvJitLink.so.*"
   --exclude "libraft.so"


### PR DESCRIPTION
Excludes `libkvikio.so` from `auditwheel repair` because KvikIO is provided as a separate wheel dependency.

Backport of #8604 for `release/26.10`.
