### PR TITLE
Fix sparse t-SNE neighbor count clamping

### DIFF
--- a/cpp/src/tsne/tsne.cu
+++ b/cpp/src/tsne/tsne.cu
@@ -1,5 +1,5 @@
 /*
- * SPDX-FileCopyrightText: Copyright (c) 2021-2025, NVIDIA CORPORATION.
+ * SPDX-FileCopyrightText: Copyright (c) 2021-2026, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
  * SPDX-License-Identifier: Apache-2.0
  */
 
@@ -40,7 +40,7 @@ void TSNE_fit(const raft::handle_t& handle,
          "Wrong input args");
 
   manifold_dense_inputs_t<float> input(X, Y, n, p);
-  knn_graph<int64_t, float> k_graph(n, params.n_neighbors, knn_indices, knn_dists);
+  auto k_graph = make_tsne_knn_graph<int64_t, float>(n, knn_indices, knn_dists, params);
 
   auto stats = _fit<manifold_dense_inputs_t<float>, knn_indices_dense_t, float>(
     handle, input, k_graph, params);
@@ -68,7 +68,7 @@ void TSNE_fit_sparse(const raft::handle_t& handle,
          "Wrong input args");
 
   manifold_sparse_inputs_t<int, float> input(indptr, indices, data, Y, nnz, n, p);
-  knn_graph<int, float> k_graph(n, params.n_neighbors, knn_indices, knn_dists);
+  auto k_graph = make_tsne_knn_graph<int, float>(n, knn_indices, knn_dists, params);
 
   auto stats = _fit<manifold_sparse_inputs_t<int, float>, knn_indices_sparse_t, float>(
     handle, input, k_graph, params);

--- a/cpp/src/tsne/tsne_runner.cuh
+++ b/cpp/src/tsne/tsne_runner.cuh
@@ -74,6 +74,8 @@ class TSNE_runner {
       CUML_LOG_WARN("FAISS only supports maximum n_neighbors = 1023.");
       params.n_neighbors = 1023;
     }
+    // Synchronize the KNN graph metadata with the clamped neighbor count.
+    k_graph.n_neighbors = params.n_neighbors;
     // Perplexity must be less than number of datapoints
     // "How to Use t-SNE Effectively" https://distill.pub/2016/misread-tsne/
     if (params.perplexity > n) params.perplexity = n;

--- a/cpp/src/tsne/tsne_runner.cuh
+++ b/cpp/src/tsne/tsne_runner.cuh
@@ -45,6 +45,20 @@ inline constexpr bool is_instance_of = std::false_type{};
 template <template <class> class U, class V>
 inline constexpr bool is_instance_of<U<V>, U> = std::true_type{};
 
+template <typename value_idx, typename value_t>
+knn_graph<value_idx, value_t> make_tsne_knn_graph(int n_rows,
+                                                  value_idx* knn_indices,
+                                                  value_t* knn_dists,
+                                                  TSNEParams& params)
+{
+  if (params.n_neighbors > n_rows) params.n_neighbors = n_rows;
+  if (params.n_neighbors > 1023) {
+    CUML_LOG_WARN("FAISS only supports maximum n_neighbors = 1023.");
+    params.n_neighbors = 1023;
+  }
+  return {n_rows, params.n_neighbors, knn_indices, knn_dists};
+}
+
 template <typename tsne_input, typename value_idx, typename value_t>
 class TSNE_runner {
  public:
@@ -69,13 +83,6 @@ class TSNE_runner {
         "Barnes Hut and FFT only work for dim == 2. Switching to exact "
         "solution.");
     }
-    if (params.n_neighbors > n) params.n_neighbors = n;
-    if (params.n_neighbors > 1023) {
-      CUML_LOG_WARN("FAISS only supports maximum n_neighbors = 1023.");
-      params.n_neighbors = 1023;
-    }
-    // Synchronize the KNN graph metadata with the clamped neighbor count.
-    k_graph.n_neighbors = params.n_neighbors;
     // Perplexity must be less than number of datapoints
     // "How to Use t-SNE Effectively" https://distill.pub/2016/misread-tsne/
     if (params.perplexity > n) params.perplexity = n;

--- a/cpp/src/tsne/tsne_runner.cuh
+++ b/cpp/src/tsne/tsne_runner.cuh
@@ -51,6 +51,7 @@ knn_graph<value_idx, value_t> make_tsne_knn_graph(int n_rows,
                                                   value_t* knn_dists,
                                                   TSNEParams& params)
 {
+  ML::default_logger().set_level(params.verbosity);
   if (params.n_neighbors > n_rows) params.n_neighbors = n_rows;
   if (params.n_neighbors > 1023) {
     CUML_LOG_WARN("FAISS only supports maximum n_neighbors = 1023.");

--- a/cpp/tests/sg/tsne_test.cu
+++ b/cpp/tests/sg/tsne_test.cu
@@ -260,39 +260,14 @@ const std::vector<TSNEInput> inputs = {
    0.98},
   {Diabetes::n_samples, Diabetes::n_features, Diabetes::diabetes, TSNE_INIT::PCA, 0.90}};
 
-TEST(TSNEValidationTest, SparseNNeighborsIsClampedInKnnGraph)
+TEST(TSNEValidationTest, NNeighborsIsClampedWhenKnnGraphIsCreated)
 {
-  raft::handle_t handle;
-  auto stream = handle.get_stream().get();
-
-  constexpr int n   = 2;
-  constexpr int p   = 1;
-  constexpr int nnz = 2;
-
-  std::vector<int> indptr_h{0, 1, 2};
-  std::vector<int> indices_h{0, 0};
-  std::vector<float> data_h{1.0f, 2.0f};
-
-  rmm::device_uvector<int> indptr(indptr_h.size(), stream);
-  rmm::device_uvector<int> indices(indices_h.size(), stream);
-  rmm::device_uvector<float> data(data_h.size(), stream);
-  rmm::device_uvector<float> embedding(n * 2, stream);
-
-  raft::update_device(indptr.data(), indptr_h.data(), indptr_h.size(), stream);
-  raft::update_device(indices.data(), indices_h.data(), indices_h.size(), stream);
-  raft::update_device(data.data(), data_h.data(), data_h.size(), stream);
+  constexpr int n = 2;
 
   TSNEParams params;
   params.n_neighbors = 3;
-  params.perplexity  = 1.0f;
-  params.max_iter    = 1;
-  params.algorithm   = TSNE_ALGORITHM::EXACT;
 
-  manifold_sparse_inputs_t<int, float> input(
-    indptr.data(), indices.data(), data.data(), embedding.data(), nnz, n, p);
-  knn_graph<int, float> k_graph(n, params.n_neighbors, nullptr, nullptr);
-  TSNE_runner<manifold_sparse_inputs_t<int, float>, knn_indices_sparse_t, float> runner(
-    handle, input, k_graph, params);
+  auto k_graph = make_tsne_knn_graph<int, float>(n, nullptr, nullptr, params);
 
   EXPECT_EQ(params.n_neighbors, n);
   EXPECT_EQ(k_graph.n_neighbors, n);

--- a/cpp/tests/sg/tsne_test.cu
+++ b/cpp/tests/sg/tsne_test.cu
@@ -260,6 +260,44 @@ const std::vector<TSNEInput> inputs = {
    0.98},
   {Diabetes::n_samples, Diabetes::n_features, Diabetes::diabetes, TSNE_INIT::PCA, 0.90}};
 
+TEST(TSNEValidationTest, SparseNNeighborsIsClampedInKnnGraph)
+{
+  raft::handle_t handle;
+  auto stream = handle.get_stream().get();
+
+  constexpr int n   = 2;
+  constexpr int p   = 1;
+  constexpr int nnz = 2;
+
+  std::vector<int> indptr_h{0, 1, 2};
+  std::vector<int> indices_h{0, 0};
+  std::vector<float> data_h{1.0f, 2.0f};
+
+  rmm::device_uvector<int> indptr(indptr_h.size(), stream);
+  rmm::device_uvector<int> indices(indices_h.size(), stream);
+  rmm::device_uvector<float> data(data_h.size(), stream);
+  rmm::device_uvector<float> embedding(n * 2, stream);
+
+  raft::update_device(indptr.data(), indptr_h.data(), indptr_h.size(), stream);
+  raft::update_device(indices.data(), indices_h.data(), indices_h.size(), stream);
+  raft::update_device(data.data(), data_h.data(), data_h.size(), stream);
+
+  TSNEParams params;
+  params.n_neighbors = 3;
+  params.perplexity  = 1.0f;
+  params.max_iter    = 1;
+  params.algorithm   = TSNE_ALGORITHM::EXACT;
+
+  manifold_sparse_inputs_t<int, float> input(
+    indptr.data(), indices.data(), data.data(), embedding.data(), nnz, n, p);
+  knn_graph<int, float> k_graph(n, params.n_neighbors, nullptr, nullptr);
+  TSNE_runner<manifold_sparse_inputs_t<int, float>, knn_indices_sparse_t, float> runner(
+    handle, input, k_graph, params);
+
+  EXPECT_EQ(params.n_neighbors, n);
+  EXPECT_EQ(k_graph.n_neighbors, n);
+}
+
 typedef TSNETest TSNETestF;
 TEST_P(TSNETestF, Result)
 {


### PR DESCRIPTION
Constructs t-SNE KNN graph metadata after clamping `n_neighbors`, keeping sparse KNN output shapes consistent with allocated buffer sizes. Adds regression coverage for the clamped graph metadata.
