### PR TITLE
Check `kwargs` for sparse input as well in `ProxyBase`

### DIFF
--- a/python/cuml/cuml/accel/estimator_proxy.py
+++ b/python/cuml/cuml/accel/estimator_proxy.py
@@ -383,10 +383,8 @@ class ProxyBase(BaseEstimator, metaclass=ProxyBaseMeta):
         from cuml.common.sparse import is_sparse
 
         if (
-            args
-            and is_sparse(args[0])
-            and "sparse" not in self._gpu.__sklearn_tags__().X_types_gpu
-        ):
+            (args and is_sparse(args[0])) or is_sparse(kwargs.get("X"))
+        ) and "sparse" not in self._gpu.__sklearn_tags__().X_types_gpu:
             raise UnsupportedOnGPU("Sparse inputs are not supported")
 
         if getattr(self._cpu, "_skl_callbacks", ()) and method in (

--- a/python/cuml/cuml_accel_tests/test_estimator_proxy.py
+++ b/python/cuml/cuml_accel_tests/test_estimator_proxy.py
@@ -601,15 +601,21 @@ def test_fit_unsupported_params():
     assert hasattr(model._cpu, "n_features_in_")
 
 
-def test_fit_unsupported_args():
+@pytest.mark.parametrize("use_kwargs", [False, True])
+def test_fit_unsupported_args(use_kwargs):
     """Hyperparameters supported on GPU, but X/y type isn't"""
     X_dense, y = make_regression(
         n_samples=100, n_features=200, random_state=42
     )
     X_dense[X_dense < 2.5] = 0.0
     X = scipy.sparse.coo_matrix(X_dense)
+
     model = RandomForestRegressor()
-    assert model.fit(X, y) is model
+    if use_kwargs:
+        out = model.fit(X=X, y=y)
+    else:
+        out = model.fit(X, y)
+    assert out is model
     # Fit happened on CPU
     check_is_fitted(model)
     assert model._gpu is None


### PR DESCRIPTION
Previously the estimator proxy in `cuml.accel` would automatically fallback for non-sparse supporting models if `args[0]` was sparse. This modifies the check to also check `kwargs` in the odd case that the user called with `kwargs` instead.