### PR TITLE
Route nested set_params to child estimators in ColumnTransformer

### DIFF
--- a/python/cuml/cuml/_thirdparty/sklearn/utils/skl_dependencies.py
+++ b/python/cuml/cuml/_thirdparty/sklearn/utils/skl_dependencies.py
@@ -11,6 +11,8 @@
 # it was since modified to allow GPU acceleration.
 # This code is under BSD 3 clause license.
 # Authors mentioned above do not endorse or promote this production.
+from collections import defaultdict
+
 from cuml.internals.base import Base
 
 
@@ -101,7 +103,16 @@ class BaseComposition:
         for name in list(params.keys()):
             if '__' not in name and name in names:
                 self._replace_estimator(attr, name, params.pop(name))
-        # 3. Step parameters and other initialisation arguments
+        # 3. Nested step parameters: route ``<name>__<param>`` to the estimator
+        nested_params = defaultdict(dict)
+        for key in list(params.keys()):
+            name, delim, sub_key = key.partition('__')
+            if delim and name in names:
+                nested_params[name][sub_key] = params.pop(key)
+        estimators = dict(getattr(self, attr))
+        for name, sub_params in nested_params.items():
+            estimators[name].set_params(**sub_params)
+        # 4. Other initialisation arguments
         super().set_params(**params)
         return self
 

--- a/python/cuml/tests/test_compose.py
+++ b/python/cuml/tests/test_compose.py
@@ -383,3 +383,33 @@ def test_column_transform_properly_handles_sub_output_type():
         ]
     ).fit(df)
     transformer.transform(df)
+
+
+@pytest.mark.parametrize("with_mean", [True, False])
+def test_column_transformer_nested_set_params(clf_dataset, with_mean):  # noqa: F811
+    X_np, X = clf_dataset
+
+    sk_selec = [0, 1]
+    cu_selec = sk_selec
+    if isinstance(X, (pd.DataFrame, cudf.DataFrame)):
+        cu_selec = ["c" + str(i) for i in sk_selec]
+
+    transformer = cuColumnTransformer(
+        [("scaler", cuStandardScaler(), cu_selec)]
+    )
+    transformer.set_params(scaler__with_mean=with_mean)
+    ft_X = transformer.fit_transform(X)
+
+    sk_transformer = skColumnTransformer(
+        [("scaler", skStandardScaler(), sk_selec)]
+    )
+    sk_transformer.set_params(scaler__with_mean=with_mean)
+    sk_t_X = sk_transformer.fit_transform(X_np)
+
+    assert_allclose(ft_X, sk_t_X)
+
+
+def test_column_transformer_set_params_invalid():
+    transformer = cuColumnTransformer([("scaler", cuStandardScaler(), [0, 1])])
+    with pytest.raises(ValueError):
+        transformer.set_params(scaler__not_a_real_param=1)


### PR DESCRIPTION
Closes #8626.

## Problem

`ColumnTransformer.set_params(<name>__<param>=value)` raises `ValueError: Invalid parameter` where scikit-learn accepts it and applies the parameter to the named transformer:

```python
from cuml.compose import ColumnTransformer
from cuml.preprocessing import StandardScaler
ct = ColumnTransformer([("s", StandardScaler(), [0, 1])])
ct.set_params(s__with_mean=False)   # ValueError: Invalid parameter 's__with_mean'
```

## Cause

`BaseComposition._set_params` (in the vendored sklearn shim) handled step replacement, then passed the remaining `name__param` keys to `super().set_params()`, relying on the base class to split the sklearn `__` delimiter and recurse into the child estimator - which is what scikit-learn's own `BaseEstimator.set_params` does. cuML's `Base.set_params` instead does a flat validity check (`if key not in valid_params: raise ValueError`), so a nested key never reaches the transformer and is reported as invalid.

## Fix

Route each `name__param` entry to the corresponding transformer inside `_set_params`, before the flat `super().set_params()` call. Step replacement (`set_params(name=estimator)`) and rejection of genuinely invalid parameters are unchanged.

## Testing

Verified against the `cuml-cu12` 26.08 wheel on a real GPU (GTX 1650):

- Reported case now matches scikit-learn's output for both `with_mean=True` and `False`, and the child transformer actually receives the parameter.
- Step replacement and invalid-parameter rejection still behave as before.

Added two tests to `python/cuml/tests/test_compose.py`:

- `test_column_transformer_nested_set_params` (cuML vs sklearn parity via the existing `clf_dataset` fixture and `assert_allclose`)
- `test_column_transformer_set_params_invalid`

Both were confirmed to **fail** against the unpatched wheel (4 parity cases raise the original `ValueError`; the invalid-param case passes either way) and **pass** with this change. Branched from `891fdef`.
